### PR TITLE
don't give default value to title + headline in AdaptiveDatePicker for Android

### DIFF
--- a/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePicker.material.kt
+++ b/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePicker.material.kt
@@ -20,19 +20,8 @@ actual fun AdaptiveDatePicker(
         state = state.datePickerState,
         modifier = modifier,
         dateFormatter = dateFormatter,
-        title = title ?: {
-            DatePickerDefaults.DatePickerTitle(
-                state = state.datePickerState,
-                modifier = Modifier.padding(DatePickerTitlePadding)
-            )
-        },
-        headline = headline ?: {
-            DatePickerDefaults.DatePickerHeadline(
-                state = state.datePickerState,
-                dateFormatter = dateFormatter,
-                modifier = Modifier.padding(DatePickerHeadlinePadding)
-            )
-        },
+        title = title,
+        headline = headline,
         showModeToggle = showModeToggle,
         colors = colors,
     )


### PR DESCRIPTION
Right now, it's not possible to have an empty headline + title on android as the default will always be provided.