### PR TITLE
Fix Typo in README.md: Change 'FilePickerType' to 'FilePickerFileType'

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Calf File Picker allows you to pick files from the device storage.
 
 ```kotlin
 val pickerLauncher = rememberFilePickerLauncher(
-    type = FilePickerType.Image,
+    type = FilePickerFileType.Image,
     selectionMode = FilePickerSelectionMode.Single,
     onResult = { files ->
         files.firstOrNull()?.let { file ->


### PR DESCRIPTION
![image](https://github.com/MohamedRejeb/Calf/assets/76798309/e4a0c372-60f6-4eef-bc83-2284bc9b0534)

Recently, I attempted to use the code provided in the README documentation for `Calf File Picker`. However, contrary to my expectations, the code did not function as intended. So I have corrected the typos in the README, and I would appreciate it if you could review the changes.