### PR TITLE
Use PHPicker if file type is image on iOS

### DIFF
--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
@@ -4,9 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.mohamedrejeb.calf.io.KmpFile
 import kotlinx.cinterop.BetaInteropApi
-import platform.Foundation.NSData
 import platform.Foundation.NSURL
-import platform.Foundation.dataWithContentsOfURL
 import platform.Photos.PHPhotoLibrary
 import platform.PhotosUI.PHPickerConfiguration
 import platform.PhotosUI.PHPickerConfigurationAssetRepresentationModeCurrent
@@ -24,7 +22,6 @@ import platform.UniformTypeIdentifiers.UTTypeAudio
 import platform.UniformTypeIdentifiers.UTTypeData
 import platform.UniformTypeIdentifiers.UTTypeFolder
 import platform.UniformTypeIdentifiers.UTTypeImage
-import platform.UniformTypeIdentifiers.UTTypeMovie
 import platform.UniformTypeIdentifiers.UTTypeText
 import platform.UniformTypeIdentifiers.UTTypeVideo
 import platform.darwin.NSObject
@@ -32,6 +29,18 @@ import platform.darwin.NSObject
 @BetaInteropApi
 @Composable
 actual fun rememberFilePickerLauncher(
+    type: FilePickerFileType,
+    selectionMode: FilePickerSelectionMode,
+    onResult: (List<KmpFile>) -> Unit,
+): FilePickerLauncher =
+    if (type == FilePickerFileType.Image) {
+        rememberImagePickerLauncher(type, selectionMode, onResult)
+    } else {
+        rememberDocumentPickerLauncher(type, selectionMode, onResult)
+    }
+
+@Composable
+private fun rememberDocumentPickerLauncher(
     type: FilePickerFileType,
     selectionMode: FilePickerSelectionMode,
     onResult: (List<KmpFile>) -> Unit,
@@ -78,6 +87,52 @@ actual fun rememberFilePickerLauncher(
     }
 }
 
+@Composable
+private fun rememberImagePickerLauncher(
+    type: FilePickerFileType,
+    selectionMode: FilePickerSelectionMode,
+    onResult: (List<KmpFile>) -> Unit,
+): FilePickerLauncher {
+    val pickerDelegate = remember {
+        object : NSObject(), PHPickerViewControllerDelegateProtocol {
+            override fun picker(picker: PHPickerViewController, didFinishPicking: List<*>) {
+                picker.dismissViewControllerAnimated(true, null)
+                println("didFinishPicking: $didFinishPicking")
+                didFinishPicking.forEach {
+                    val result = it as? PHPickerResult ?: return@forEach
+                    result.itemProvider.loadFileRepresentationForTypeIdentifier(
+                        typeIdentifier = UTTypeImage.identifier,
+                    ) { url, error ->
+                        if (error != null) {
+                            println("Error: $error")
+                            return@loadFileRepresentationForTypeIdentifier
+                        }
+                        onResult(listOfNotNull(url))
+                    }
+                }
+            }
+        }
+    }
+
+    return remember {
+        FilePickerLauncher(
+            type = type,
+            selectionMode = selectionMode,
+            onLaunch = {
+                val imagePicker = createPHPickerViewController(
+                    delegate = pickerDelegate,
+                    selectionMode = selectionMode,
+                )
+                UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
+                    imagePicker,
+                    true,
+                    null
+                )
+            }
+        )
+    }
+}
+
 private fun createUIDocumentPickerViewController(
     delegate: UIDocumentPickerDelegateProtocol,
     type: FilePickerFileType,
@@ -103,6 +158,27 @@ private fun createUIDocumentPickerViewController(
     pickerController.delegate = delegate
     pickerController.allowsMultipleSelection = selectionMode == FilePickerSelectionMode.Multiple
     return pickerController
+}
+
+private fun createPHPickerViewController(
+    delegate: PHPickerViewControllerDelegateProtocol,
+    selectionMode: FilePickerSelectionMode,
+): PHPickerViewController {
+    val configuration = PHPickerConfiguration(PHPhotoLibrary.sharedPhotoLibrary())
+    val newFilter = PHPickerFilter.anyFilterMatchingSubfilters(
+        listOf(
+            PHPickerFilter.imagesFilter(),
+        )
+    )
+    configuration.filter = newFilter
+    configuration.preferredAssetRepresentationMode =
+        PHPickerConfigurationAssetRepresentationModeCurrent
+    configuration.selection = PHPickerConfigurationSelectionOrdered
+    configuration.selectionLimit = if (selectionMode == FilePickerSelectionMode.Multiple) 0 else 1
+    configuration.preselectedAssetIdentifiers = listOf<Nothing>()
+    val picker = PHPickerViewController(configuration)
+    picker.delegate = delegate
+    return picker
 }
 
 actual class FilePickerLauncher actual constructor(

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/AppNavGraph.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/AppNavGraph.kt
@@ -9,6 +9,7 @@ import com.mohamedrejeb.calf.sample.ui.DatePickerScreen
 import com.mohamedrejeb.calf.sample.ui.DropDownMenuScreen
 import com.mohamedrejeb.calf.sample.ui.FilePickerScreen
 import com.mohamedrejeb.calf.sample.ui.HomeScreen
+import com.mohamedrejeb.calf.sample.ui.ImagePickerScreen
 import com.mohamedrejeb.calf.sample.ui.MapScreen
 import com.mohamedrejeb.calf.sample.ui.PermissionScreen
 import com.mohamedrejeb.calf.sample.ui.ProgressBarScreen
@@ -82,6 +83,13 @@ fun AppNavGraph(
         }
         composable(Screen.FilePicker.name) {
             FilePickerScreen(
+                navigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+        composable(Screen.ImagePicker.name) {
+            ImagePickerScreen(
                 navigateBack = {
                     navController.popBackStack()
                 }

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/Screen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/Screen.kt
@@ -9,6 +9,7 @@ enum class Screen {
     ProgressBar,
     Switch,
     FilePicker,
+    ImagePicker,
     WebView,
     Permission,
     Map,

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/FilePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/FilePickerScreen.kt
@@ -2,6 +2,7 @@ package com.mohamedrejeb.calf.sample.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,8 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material3.Button
@@ -29,6 +32,7 @@ import com.mohamedrejeb.calf.io.name
 import com.mohamedrejeb.calf.picker.FilePickerFileType
 import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
 import com.mohamedrejeb.calf.picker.rememberFilePickerLauncher
+import com.mohamedrejeb.calf.ui.toggle.AdaptiveSwitch
 
 @Composable
 fun FilePickerScreen(
@@ -37,7 +41,15 @@ fun FilePickerScreen(
     var fileNames by remember {
         mutableStateOf<List<String>>(emptyList())
     }
-    val pickerLauncher = rememberFilePickerLauncher(
+    var isMultiple by remember { mutableStateOf(false) }
+    val singlePickerLauncher = rememberFilePickerLauncher(
+        type = FilePickerFileType.All,
+        selectionMode = FilePickerSelectionMode.Single,
+        onResult = { files ->
+            fileNames = files.map { it.name.orEmpty() }
+        },
+    )
+    val multiplePickerLauncher = rememberFilePickerLauncher(
         type = FilePickerFileType.All,
         selectionMode = FilePickerSelectionMode.Multiple,
         onResult = { files ->
@@ -51,6 +63,7 @@ fun FilePickerScreen(
             .background(MaterialTheme.colorScheme.background)
             .windowInsetsPadding(WindowInsets.systemBars)
             .windowInsetsPadding(WindowInsets.ime)
+            .verticalScroll(rememberScrollState())
     ) {
         IconButton(
             onClick = {
@@ -66,9 +79,20 @@ fun FilePickerScreen(
             )
         }
 
+        Row(Modifier.padding(16.dp)) {
+            Text("Select multiple files?", Modifier.weight(1f))
+            AdaptiveSwitch(isMultiple, onCheckedChange = { checked ->
+                isMultiple = checked
+            })
+        }
+
         Button(
             onClick = {
-                pickerLauncher.launch()
+                if (isMultiple) {
+                    multiplePickerLauncher.launch()
+                } else {
+                    singlePickerLauncher.launch()
+                }
             },
             modifier = Modifier.padding(16.dp)
         ) {

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/FilePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/FilePickerScreen.kt
@@ -1,42 +1,47 @@
 package com.mohamedrejeb.calf.sample.ui
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.ArrowBackIosNew
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import com.mohamedrejeb.calf.io.readByteArray
-import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
+import com.mohamedrejeb.calf.io.name
 import com.mohamedrejeb.calf.picker.FilePickerFileType
+import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
 import com.mohamedrejeb.calf.picker.rememberFilePickerLauncher
-import com.mohamedrejeb.calf.picker.toImageBitmap
 
 @Composable
 fun FilePickerScreen(
     navigateBack: () -> Unit
 ) {
-    var imageBitmap by remember {
-        mutableStateOf<ImageBitmap?>(null)
+    var fileNames by remember {
+        mutableStateOf<List<String>>(emptyList())
     }
     val pickerLauncher = rememberFilePickerLauncher(
-        type = FilePickerFileType.Image,
-        selectionMode = FilePickerSelectionMode.Single,
+        type = FilePickerFileType.All,
+        selectionMode = FilePickerSelectionMode.Multiple,
         onResult = { files ->
-            files.firstOrNull()?.let { file ->
-                imageBitmap = try {
-                    file.readByteArray().toImageBitmap()
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                    null
-                }
-            }
+            fileNames = files.map { it.name.orEmpty() }
         },
     )
 
@@ -67,24 +72,19 @@ fun FilePickerScreen(
             },
             modifier = Modifier.padding(16.dp)
         ) {
-            Text("Pick File")
+            Text("Pick Files")
         }
 
         Text(
-            text = "File picked:",
+            text = "Files picked:",
             style = MaterialTheme.typography.titleLarge,
             modifier = Modifier.padding(16.dp)
         )
-
-        imageBitmap?.let {
-            Image(
-                bitmap = it,
-                contentDescription = "Image",
-                contentScale = ContentScale.FillWidth,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-                    .clip(MaterialTheme.shapes.medium)
+        Spacer(Modifier.height(8.dp))
+        fileNames.forEach {
+            Text(
+                text = "- $it",
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
             )
         }
     }

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/HomeScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowForwardIos
 import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.Camera
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.Pages
 import androidx.compose.material.icons.outlined.PunchClock
@@ -136,6 +137,11 @@ fun HomeScreen(
                     onClick = { navigate(Screen.FilePicker.name) },
                     title = "Adaptive File Picker",
                     icon = Icons.Outlined.AttachFile,
+                )
+                ListItem(
+                    onClick = { navigate(Screen.ImagePicker.name) },
+                    title = "Adaptive Image Picker",
+                    icon = Icons.Outlined.Camera,
                 )
                 ListItem(
                     onClick = { navigate(Screen.WebView.name) },

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/ImagePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/ui/ImagePickerScreen.kt
@@ -1,0 +1,91 @@
+package com.mohamedrejeb.calf.sample.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.calf.io.readByteArray
+import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
+import com.mohamedrejeb.calf.picker.FilePickerFileType
+import com.mohamedrejeb.calf.picker.rememberFilePickerLauncher
+import com.mohamedrejeb.calf.picker.toImageBitmap
+
+@Composable
+fun ImagePickerScreen(
+    navigateBack: () -> Unit
+) {
+    var imageBitmap by remember {
+        mutableStateOf<ImageBitmap?>(null)
+    }
+    val pickerLauncher = rememberFilePickerLauncher(
+        type = FilePickerFileType.Image,
+        selectionMode = FilePickerSelectionMode.Single,
+        onResult = { files ->
+            files.firstOrNull()?.let { file ->
+                imageBitmap = try {
+                    file.readByteArray().toImageBitmap()
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    null
+                }
+            }
+        },
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .windowInsetsPadding(WindowInsets.systemBars)
+            .windowInsetsPadding(WindowInsets.ime)
+    ) {
+        IconButton(
+            onClick = {
+                navigateBack()
+            },
+            modifier = Modifier
+                .padding(16.dp)
+        ) {
+            Icon(
+                Icons.Filled.ArrowBackIosNew,
+                contentDescription = "Back",
+                tint = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+
+        Button(
+            onClick = {
+                pickerLauncher.launch()
+            },
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text("Pick image")
+        }
+
+        Text(
+            text = "Image picked:",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(16.dp)
+        )
+
+        imageBitmap?.let {
+            Image(
+                bitmap = it,
+                contentDescription = "Image",
+                contentScale = ContentScale.FillWidth,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .clip(MaterialTheme.shapes.medium)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #35 

I just copied the logic you previously had to use the PHPicker, but it's running only if the desired file type is an image.

Let me know if something else is required. Maybe a different screen in the sample to select an image or a pdf and thus check that the document picker is correctly run would be good.

<img width="250" alt="image" src="https://github.com/MohamedRejeb/Calf/assets/11753209/bc2062a1-c06a-4622-a551-439913c89a06">