### PR TITLE
Add a Coil utils module and a KmpFileFetcher

### DIFF
--- a/calf-file-picker-coil/build.gradle.kts
+++ b/calf-file-picker-coil/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+}
+
+modulePublicationSetup()
+androidLibrarySetup()
+
+kotlin {
+    applyHierarchyTemplate()
+    applyTargets()
+    sourceSets.commonMain.dependencies {
+        api(projects.calfCore)
+        api(projects.calfIo)
+        implementation(libs.coil)
+    }
+}

--- a/calf-file-picker-coil/src/androidMain/kotlin/com.mohamedrejeb.calf/picker/coil/KmpFileFetcher.android.kt
+++ b/calf-file-picker-coil/src/androidMain/kotlin/com.mohamedrejeb.calf/picker/coil/KmpFileFetcher.android.kt
@@ -1,0 +1,6 @@
+package com.mohamedrejeb.calf.picker.coil
+
+import com.mohamedrejeb.calf.core.PlatformContext
+
+actual fun coil3.PlatformContext.toCalfPlatformContext(): PlatformContext =
+    this

--- a/calf-file-picker-coil/src/commonMain/kotlin/com.mohamedrejeb.calf/picker/coil/KmpFileFetcher.kt
+++ b/calf-file-picker-coil/src/commonMain/kotlin/com.mohamedrejeb.calf/picker/coil/KmpFileFetcher.kt
@@ -1,0 +1,44 @@
+package com.mohamedrejeb.calf.picker.coil
+
+import coil3.ImageLoader
+import coil3.decode.DataSource
+import coil3.decode.ImageSource
+import coil3.fetch.FetchResult
+import coil3.fetch.Fetcher
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import com.mohamedrejeb.calf.io.KmpFile
+import com.mohamedrejeb.calf.io.readByteArray
+import com.mohamedrejeb.calf.core.PlatformContext
+import okio.Buffer
+
+expect fun coil3.PlatformContext.toCalfPlatformContext(): PlatformContext
+
+class KmpFileFetcher(
+    private val file: KmpFile,
+    private val options: Options,
+) : Fetcher {
+
+    override suspend fun fetch(): FetchResult {
+        return SourceFetchResult(
+            source = ImageSource(
+                source = Buffer().apply {
+                    write(file.readByteArray(options.context.toCalfPlatformContext()))
+                },
+                fileSystem = options.fileSystem,
+            ),
+            mimeType = null,
+            dataSource = DataSource.MEMORY,
+        )
+    }
+
+    class Factory : Fetcher.Factory<KmpFile> {
+        override fun create(
+            data: KmpFile,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Fetcher {
+            return KmpFileFetcher(data, options)
+        }
+    }
+}

--- a/calf-file-picker-coil/src/nonAndroidMain/kotlin/com.mohamedrejeb.calf/picker/coil/KmpFileFetcher.nonAndroid.kt
+++ b/calf-file-picker-coil/src/nonAndroidMain/kotlin/com.mohamedrejeb.calf/picker/coil/KmpFileFetcher.nonAndroid.kt
@@ -1,0 +1,6 @@
+package com.mohamedrejeb.calf.picker.coil
+
+import com.mohamedrejeb.calf.core.PlatformContext
+
+actual fun coil3.PlatformContext.toCalfPlatformContext(): PlatformContext =
+    PlatformContext.INSTANCE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ compose = "1.6.0"
 kotlinx-serialization-json = "1.6.2"
 nexus-publish = "2.0.0-rc-1"
 documentfile = "1.0.1"
+coil = "3.0.0-alpha06"
 
 conventionPlugin = "0.1.0"
 calf = "0.4.0"
@@ -35,6 +36,7 @@ kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-
 kotlinx-coroutines-javafx = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-javafx", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 nexus-publish = { module = "io.github.gradle-nexus.publish-plugin:io.github.gradle-nexus.publish-plugin.gradle.plugin", version.ref = "nexus-publish" }
+coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 
 # Android
 documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,7 @@ include(
     ":calf-permissions",
     ":calf-geo",
     ":calf-maps",
+    ":calf-file-picker-coil",
     // Sample modules
     ":sample:android",
     ":sample:desktop",


### PR DESCRIPTION
Coil is a well-known network image loading library use by many people. In Coil, you can [extend the image loading pipeline](https://coil-kt.github.io/coil/image_pipeline/) by adding, among others, custom fetchers that will express how to download an image given any model.

This PR adds a custom Coil Fetcher to be able to pass a `KmpFile` to Coil and it will display the local image gracefully.