### PR TITLE
Android notification permission opens notification settings

### DIFF
--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/PermissionsScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/PermissionsScreen.kt
@@ -110,7 +110,24 @@ private fun PermissionItem(permission: Permission) {
         )
     }
 
+
+
     Spacer(modifier = Modifier.height(16.dp))
+
+    if (permission == Permission.Notification) {
+        Button(
+            onClick = {
+                permissionState.openAppSettings()
+            },
+        ) {
+            Text(
+                text = "Open Notification Settings",
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+
 
     HorizontalDivider()
 }


### PR DESCRIPTION
A small feature that launches notification settings instead of the default app settings screen.

Great work with this library!

