### PR TITLE
Plumb down modifier parameter in iOS AdaptiveBottomSheet

### DIFF
--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/sheet/AdaptiveBottomSheet.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/sheet/AdaptiveBottomSheet.ios.kt
@@ -49,7 +49,7 @@ actual fun AdaptiveBottomSheet(
                 CompositionLocalProvider(compositionLocalContext) {
                     CompositionLocalProvider(sheetCompositionLocalContext) {
                         Column(
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = modifier.fillMaxSize(),
                             content = content,
                         )
                     }


### PR DESCRIPTION
Previously it wasn't being used