### PR TITLE
[iOS] Picker not displayed when not on main view controller

### DIFF
--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
@@ -25,6 +25,7 @@ import platform.PhotosUI.PHPickerViewControllerDelegateProtocol
 import platform.UIKit.UIApplication
 import platform.UIKit.UIDocumentPickerDelegateProtocol
 import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIViewController
 import platform.UniformTypeIdentifiers.UTType
 import platform.UniformTypeIdentifiers.UTTypeApplication
 import platform.UniformTypeIdentifiers.UTTypeAudio
@@ -126,7 +127,7 @@ private fun rememberDocumentPickerLauncher(
                         selectionMode = selectionMode,
                     )
 
-                UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
+                findTopViewController()?.presentViewController(
                     pickerController,
                     true,
                     null,
@@ -184,7 +185,7 @@ private fun rememberImageVideoPickerLauncher(
                         selectionMode = selectionMode,
                     )
 
-                UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
+                findTopViewController()?.presentViewController(
                     imagePicker,
                     true,
                     null,
@@ -256,6 +257,7 @@ private fun createUIDocumentPickerViewController(
     return pickerController
 }
 
+
 private fun createPHPickerViewController(
     delegate: PHPickerViewControllerDelegateProtocol,
     type: FilePickerFileType,
@@ -287,6 +289,16 @@ private fun createPHPickerViewController(
     picker.delegate = delegate
     return picker
 }
+
+fun findTopViewController(): UIViewController? {
+    val keyWindow = UIApplication.sharedApplication.keyWindow
+    var topController = keyWindow?.rootViewController
+    while (topController?.presentedViewController != null) {
+        topController = topController.presentedViewController
+    }
+    return topController
+}
+
 
 actual class FilePickerLauncher actual constructor(
     type: FilePickerFileType,

--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
@@ -117,7 +117,7 @@ private fun rememberDocumentPickerLauncher(
             }
         }
 
-    return remember {
+    return remember(currentUIViewController) {
         FilePickerLauncher(
             type = type,
             selectionMode = selectionMode,
@@ -176,7 +176,7 @@ private fun rememberImageVideoPickerLauncher(
         }
     }
 
-    return remember {
+    return remember(currentUIViewController) {
         FilePickerLauncher(
             type = type,
             selectionMode = selectionMode,

--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
@@ -58,6 +58,7 @@ private fun rememberDocumentPickerLauncher(
     onResult: (List<KmpFile>) -> Unit,
 ): FilePickerLauncher {
     val scope = rememberCoroutineScope()
+    val currentUIViewController = LocalUIViewController.current
 
     val delegate =
         remember {
@@ -127,7 +128,7 @@ private fun rememberDocumentPickerLauncher(
                         selectionMode = selectionMode,
                     )
 
-                findTopViewController()?.presentViewController(
+                currentUIViewController.presentViewController(
                     pickerController,
                     true,
                     null,
@@ -144,6 +145,7 @@ private fun rememberImageVideoPickerLauncher(
     onResult: (List<KmpFile>) -> Unit,
 ): FilePickerLauncher {
     val scope = rememberCoroutineScope()
+    val currentUIViewController = LocalUIViewController.current
 
     val pickerDelegate = remember {
         object : NSObject(), PHPickerViewControllerDelegateProtocol {
@@ -185,7 +187,7 @@ private fun rememberImageVideoPickerLauncher(
                         selectionMode = selectionMode,
                     )
 
-                findTopViewController()?.presentViewController(
+                currentUIViewController.presentViewController(
                     imagePicker,
                     true,
                     null,
@@ -288,15 +290,6 @@ private fun createPHPickerViewController(
     val picker = PHPickerViewController(configuration)
     picker.delegate = delegate
     return picker
-}
-
-fun findTopViewController(): UIViewController? {
-    val keyWindow = UIApplication.sharedApplication.keyWindow
-    var topController = keyWindow?.rootViewController
-    while (topController?.presentedViewController != null) {
-        topController = topController.presentedViewController
-    }
-    return topController
 }
 
 

--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
@@ -3,6 +3,7 @@ package com.mohamedrejeb.calf.picker
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.interop.LocalUIViewController
 import com.mohamedrejeb.calf.core.InternalCalfApi
 import com.mohamedrejeb.calf.io.KmpFile
 import kotlinx.cinterop.BetaInteropApi


### PR DESCRIPTION
Retrieve the top view controller from the view hierarchy and display picker.

In the current versión i get this error: 

Attempt to present <UIDocumentPickerViewController: 0x10c80ac00> on <_.MainViewController: 0x10a0099f0> (from <_.MainViewController: 0x10a0099f0>) whose view is not in the window hierarchy.