### PR TITLE
change onPermissionResult: (Boolean)->Unit to onPermissionResult: (PermissionStatus) -> Unit

### DIFF
--- a/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/MutableMultiplePermissionsState.android.kt
+++ b/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/MutableMultiplePermissionsState.android.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 @Composable
 internal actual fun rememberMutableMultiplePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit
 ): MultiplePermissionsState {
     // Create mutable permissions that can be requested individually
     val mutablePermissions = rememberMutablePermissionsState(permissions, onPermissionsResult)
@@ -46,7 +46,10 @@ internal actual fun rememberMutableMultiplePermissionsState(
             .filter { it.key != null }
             .mapKeys { it.key!! }
         multiplePermissionsState.updatePermissionsStatus(result)
-        onPermissionsResult(result)
+        val permissionWithStatus = multiplePermissionsState.permissions.associate  {
+             Pair(it.permission, it.status)
+        }
+        onPermissionsResult(permissionWithStatus)
     }
     DisposableEffect(multiplePermissionsState, launcher) {
         multiplePermissionsState.launcher = launcher
@@ -62,7 +65,7 @@ internal actual fun rememberMutableMultiplePermissionsState(
 @Composable
 private fun rememberMutablePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit
 ): List<MutablePermissionState> {
     // Create list of MutablePermissionState for each permission
     val context = LocalContext.current
@@ -73,8 +76,8 @@ private fun rememberMutablePermissionsState(
                 permission,
                 context,
                 activity,
-            ) { isGranted ->
-                onPermissionsResult(mapOf(permission to isGranted))
+            ) { permissionState ->
+                onPermissionsResult(mapOf(permission to permissionState))
             }
         }
     }

--- a/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/MutablePermissionState.android.kt
+++ b/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/MutablePermissionState.android.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 @Composable
 internal actual fun rememberMutablePermissionState(
     permission: Permission,
-    onPermissionResult: (Boolean) -> Unit,
+    onPermissionResult: (PermissionStatus) -> Unit,
 ): MutablePermissionState {
     val context = LocalContext.current
     val permissionState = remember(permission) {
@@ -46,7 +46,7 @@ internal actual fun rememberMutablePermissionState(
     // Remember RequestPermission launcher and assign it to permissionState
     val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
         permissionState.refreshPermissionStatus()
-        onPermissionResult(it)
+        onPermissionResult(permissionState.status)
     }
     DisposableEffect(permissionState, launcher) {
         permissionState.launcher = launcher
@@ -73,7 +73,7 @@ internal class MutablePermissionStateImpl(
     override val permission: Permission,
     private val context: Context,
     private val activity: Activity,
-    private val onPermissionResult: (Boolean) -> Unit,
+    private val onPermissionResult: (PermissionStatus) -> Unit,
 ) : MutablePermissionState {
 
     private val androidPermission = permission.toAndroidPermission()
@@ -83,7 +83,7 @@ internal class MutablePermissionStateImpl(
     override fun launchPermissionRequest() {
         if (androidPermission.isEmpty() || permission.isAlwaysGranted()) {
             refreshPermissionStatus()
-            onPermissionResult(true)
+            onPermissionResult(status)
             return
         }
 

--- a/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/MultiplePermissionsState.kt
+++ b/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/MultiplePermissionsState.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Stable
 @Composable
 fun rememberMultiplePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit = {}
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit = {}
 ): MultiplePermissionsState {
     return rememberMutableMultiplePermissionsState(permissions, onPermissionsResult)
 }

--- a/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.kt
+++ b/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.getValue
 @Composable
 internal expect fun rememberMutableMultiplePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit = {}
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit = {}
 ): MultiplePermissionsState
 
 /**

--- a/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.kt
+++ b/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Stable
 @Composable
 internal expect fun rememberMutablePermissionState(
     permission: Permission,
-    onPermissionResult: (Boolean) -> Unit = {}
+    onPermissionResult: (PermissionStatus) -> Unit = {}
 ): MutablePermissionState
 
 /**

--- a/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionState.kt
+++ b/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionState.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Stable
 @Composable
 fun rememberPermissionState(
     permission: Permission,
-    onPermissionResult: (Boolean) -> Unit = {},
+    onPermissionResult: (PermissionStatus) -> Unit = {},
 ): PermissionState {
     return rememberMutablePermissionState(permission, onPermissionResult)
 }

--- a/calf-permissions/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/MutableMultiplePermissionsState.desktop.kt
+++ b/calf-permissions/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/MutableMultiplePermissionsState.desktop.kt
@@ -21,12 +21,12 @@ import androidx.compose.runtime.remember
 @Composable
 internal actual fun rememberMutableMultiplePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit
 ): MultiplePermissionsState {
     // Create mutable permissions that can be requested individually
     val mutablePermissions = permissions.map { permission ->
-        rememberMutablePermissionState(permission) { granted ->
-            onPermissionsResult(mapOf(permission to granted))
+        rememberMutablePermissionState(permission) { permissionStatus ->
+            onPermissionsResult(mapOf(permission to permissionStatus))
         }
     }
 

--- a/calf-permissions/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/MutablePermissionState.desktop.kt
+++ b/calf-permissions/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/MutablePermissionState.desktop.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.setValue
 @Composable
 internal actual fun rememberMutablePermissionState(
     permission: Permission,
-    onPermissionResult: (Boolean) -> Unit
+    onPermissionResult: (PermissionStatus) -> Unit
 ): MutablePermissionState {
     return remember(permission) {
         MutablePermissionStateImpl(permission)

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.ios.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.ios.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.getValue
 @Composable
 internal actual fun rememberMutableMultiplePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit
 ): MultiplePermissionsState {
     TODO()
 }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.ios.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.ios.kt
@@ -28,7 +28,7 @@ import platform.UIKit.UIApplicationOpenSettingsURLString
 @Composable
 internal actual fun rememberMutablePermissionState(
     permission: Permission,
-    onPermissionResult: (Boolean) -> Unit,
+    onPermissionResult: (PermissionStatus) -> Unit,
 ): MutablePermissionState {
     val scope = rememberCoroutineScope()
 
@@ -55,7 +55,7 @@ internal actual fun rememberMutablePermissionState(
 @Stable
 internal class MutablePermissionStateImpl(
     override val permission: Permission,
-    private val onPermissionResult: (Boolean) -> Unit,
+    private val onPermissionResult: (PermissionStatus) -> Unit,
     private val scope: CoroutineScope,
 ) : MutablePermissionState {
 

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/PermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/PermissionHelper.kt
@@ -4,7 +4,7 @@ import com.mohamedrejeb.calf.permissions.ExperimentalPermissionsApi
 import com.mohamedrejeb.calf.permissions.PermissionStatus
 
 internal interface PermissionHelper {
-    fun launchPermissionRequest(onPermissionResult: (Boolean) -> Unit)
+    fun launchPermissionRequest(onPermissionResult: (PermissionStatus) -> Unit)
 
     @OptIn(ExperimentalPermissionsApi::class)
     fun getPermissionStatus(

--- a/calf-permissions/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.js.kt
+++ b/calf-permissions/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.js.kt
@@ -20,12 +20,12 @@ import androidx.compose.runtime.remember
 @Composable
 internal actual fun rememberMutableMultiplePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit
 ): MultiplePermissionsState {
     // Create mutable permissions that can be requested individually
     val mutablePermissions = permissions.map { permission ->
-        rememberMutablePermissionState(permission) { granted ->
-            onPermissionsResult(mapOf(permission to granted))
+        rememberMutablePermissionState(permission) { permissionStatus ->
+            onPermissionsResult(mapOf(permission to permissionStatus))
         }
     }
 

--- a/calf-permissions/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.js.kt
+++ b/calf-permissions/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.js.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.setValue
 @Composable
 internal actual fun rememberMutablePermissionState(
     permission: Permission,
-    onPermissionResult: (Boolean) -> Unit,
+    onPermissionResult: (PermissionStatus) -> Unit,
 ): MutablePermissionState {
     return remember(permission) {
         MutablePermissionStateImpl(permission)

--- a/calf-permissions/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.wasmJs.kt
+++ b/calf-permissions/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/MutableMultiplePermissionsState.wasmJs.kt
@@ -20,13 +20,13 @@ import androidx.compose.runtime.remember
 @Composable
 internal actual fun rememberMutableMultiplePermissionsState(
     permissions: List<Permission>,
-    onPermissionsResult: (Map<Permission, Boolean>) -> Unit,
+    onPermissionsResult: (Map<Permission, PermissionStatus>) -> Unit,
 ): MultiplePermissionsState {
     // Create mutable permissions that can be requested individually
     val mutablePermissions =
         permissions.map { permission ->
-            rememberMutablePermissionState(permission) { granted ->
-                onPermissionsResult(mapOf(permission to granted))
+            rememberMutablePermissionState(permission) { permissionStatus ->
+                onPermissionsResult(mapOf(permission to permissionStatus))
             }
         }
 

--- a/calf-permissions/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.wasmJs.kt
+++ b/calf-permissions/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.wasmJs.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.setValue
 @Composable
 internal actual fun rememberMutablePermissionState(
     permission: Permission,
-    onPermissionResult: (Boolean) -> Unit,
+    onPermissionResult: (PermissionStatus) -> Unit,
 ): MutablePermissionState {
     return remember(permission) {
         MutablePermissionStateImpl(permission)


### PR DESCRIPTION
use `(Boolean)->Unit`

```kotlin
lateinit var galleryVideoPermission: PermissionState
  galleryVideoPermission = rememberPermissionState(
    permission = Permission.Gallery,
  ) {
    if (it) {
      videoPickerLauncher.launch()
    } else {
      if (galleryVideoPermission.status.shouldShowRationale){
        galleryVideoPermission.openAppSettings()
      }
    }
  }
```

use `(PermissionState)->Unit`
```kotlin
val galleryVideoPermission = rememberPermissionState(
    permission = Permission.Gallery,
  ) {
    if (it.isGranted) {
      videoPickerLauncher.launch()
    } else {
      if (it.shouldShowRationale){
        galleryVideoPermission.openAppSettings()
      }
    }
  }
```

[already fork. make it working. for now `rememberMutableMultiplePermissionsState` got some error. it use boolean.](https://github.com/MohamedRejeb/Calf/issues/177)

