### PR TITLE
Fix openAppSettings on iOS 18

### DIFF
--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.ios.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.ios.kt
@@ -78,7 +78,7 @@ internal class MutablePermissionStateImpl(
 
     override fun openAppSettings() {
         val settingsUrl = NSURL.URLWithString(UIApplicationOpenSettingsURLString) ?: return
-        UIApplication.sharedApplication.openURL(settingsUrl)
+        UIApplication.sharedApplication.openURL(settingsUrl, emptyMap<Any?, String>(), null)
     }
 
     override fun refreshPermissionStatus() {


### PR DESCRIPTION
On iOS 18, openAppSettings() for notifications fails with:

```
BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).
```

Here is a relevant apple thread: https://forums.developer.apple.com/forums/thread/763568

This PR fixes the issue.