### PR TITLE
Permissions: If a permission has not been determined shouldShowRationale is now false, if it has been denied shouldShowRationale is now true.

### DIFF
--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/AVCapturePermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/AVCapturePermissionHelper.kt
@@ -4,6 +4,7 @@ import com.mohamedrejeb.calf.permissions.ExperimentalPermissionsApi
 import com.mohamedrejeb.calf.permissions.PermissionStatus
 import platform.AVFoundation.AVAuthorizationStatus
 import platform.AVFoundation.AVAuthorizationStatusAuthorized
+import platform.AVFoundation.AVAuthorizationStatusDenied
 import platform.AVFoundation.AVAuthorizationStatusNotDetermined
 import platform.AVFoundation.AVCaptureDevice
 import platform.AVFoundation.AVMediaType
@@ -33,10 +34,13 @@ internal class AVCapturePermissionHelper(
                 PermissionStatus.Granted
 
             AVAuthorizationStatusNotDetermined ->
+                PermissionStatus.Denied(shouldShowRationale = false)
+
+            AVAuthorizationStatusDenied ->
                 PermissionStatus.Denied(shouldShowRationale = true)
 
             else ->
-                PermissionStatus.Denied(shouldShowRationale = false)
+                PermissionStatus.Denied(shouldShowRationale = true)
         }
 
         onPermissionResult(permissionStatus)

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/BluetoothPermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/BluetoothPermissionHelper.kt
@@ -8,6 +8,7 @@ import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
 import platform.CoreBluetooth.CBManager
 import platform.CoreBluetooth.CBManagerAuthorization
 import platform.CoreBluetooth.CBManagerAuthorizationAllowedAlways
+import platform.CoreBluetooth.CBManagerAuthorizationDenied
 import platform.CoreBluetooth.CBManagerAuthorizationNotDetermined
 import platform.CoreBluetooth.CBManagerStatePoweredOn
 import platform.CoreBluetooth.CBManagerStateUnknown
@@ -39,10 +40,13 @@ internal class BluetoothPermissionHelper : PermissionHelper {
                     onPermissionResult(PermissionStatus.Granted)
 
                 CBManagerAuthorizationNotDetermined ->
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
+
+                CBManagerAuthorizationDenied ->
                     onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
 
                 else ->
-                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
             }
         } else {
             val state = CBCentralManager().state
@@ -51,10 +55,10 @@ internal class BluetoothPermissionHelper : PermissionHelper {
                     onPermissionResult(PermissionStatus.Granted)
 
                 CBManagerStateUnknown ->
-                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
 
                 else ->
-                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
             }
         }
     }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/ContactPermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/ContactPermissionHelper.kt
@@ -4,6 +4,7 @@ import com.mohamedrejeb.calf.permissions.ExperimentalPermissionsApi
 import com.mohamedrejeb.calf.permissions.PermissionStatus
 import platform.Contacts.CNAuthorizationStatus
 import platform.Contacts.CNAuthorizationStatusAuthorized
+import platform.Contacts.CNAuthorizationStatusDenied
 import platform.Contacts.CNAuthorizationStatusNotDetermined
 import platform.Contacts.CNContactStore
 import platform.Contacts.CNEntityType
@@ -24,9 +25,14 @@ internal class ContactPermissionHelper : PermissionHelper {
     override fun getPermissionStatus(onPermissionResult: (PermissionStatus) -> Unit) {
         val permissionStatus = when (getCurrentAuthorizationStatus()) {
             CNAuthorizationStatusAuthorized -> PermissionStatus.Granted
+
             CNAuthorizationStatusNotDetermined ->
+                PermissionStatus.Denied(shouldShowRationale = false)
+
+            CNAuthorizationStatusDenied ->
                 PermissionStatus.Denied(shouldShowRationale = true)
-            else -> PermissionStatus.Denied(shouldShowRationale = false)
+
+            else -> PermissionStatus.Denied(shouldShowRationale = true)
         }
         onPermissionResult(permissionStatus)
     }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/GalleryPermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/GalleryPermissionHelper.kt
@@ -4,6 +4,7 @@ import com.mohamedrejeb.calf.permissions.ExperimentalPermissionsApi
 import com.mohamedrejeb.calf.permissions.PermissionStatus
 import platform.Photos.PHAuthorizationStatus
 import platform.Photos.PHAuthorizationStatusAuthorized
+import platform.Photos.PHAuthorizationStatusDenied
 import platform.Photos.PHAuthorizationStatusNotDetermined
 import platform.Photos.PHPhotoLibrary
 
@@ -28,10 +29,13 @@ internal class GalleryPermissionHelper : PermissionHelper {
                 PermissionStatus.Granted
 
             PHAuthorizationStatusNotDetermined ->
+                PermissionStatus.Denied(shouldShowRationale = false)
+
+            PHAuthorizationStatusDenied ->
                 PermissionStatus.Denied(shouldShowRationale = true)
 
             else ->
-                PermissionStatus.Denied(shouldShowRationale = false)
+                PermissionStatus.Denied(shouldShowRationale = true)
         }
         onPermissionResult(permissionStatus)
     }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/LocalNotificationPermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/LocalNotificationPermissionHelper.kt
@@ -6,6 +6,7 @@ import platform.UserNotifications.UNAuthorizationOptionAlert
 import platform.UserNotifications.UNAuthorizationOptionBadge
 import platform.UserNotifications.UNAuthorizationOptionSound
 import platform.UserNotifications.UNAuthorizationStatusAuthorized
+import platform.UserNotifications.UNAuthorizationStatusDenied
 import platform.UserNotifications.UNAuthorizationStatusEphemeral
 import platform.UserNotifications.UNAuthorizationStatusNotDetermined
 import platform.UserNotifications.UNAuthorizationStatusProvisional
@@ -45,10 +46,13 @@ internal class LocalNotificationPermissionHelper : PermissionHelper {
                     onPermissionResult(PermissionStatus.Granted)
 
                 UNAuthorizationStatusNotDetermined ->
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
+
+                UNAuthorizationStatusDenied ->
                     onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
 
                 else ->
-                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
             }
         }
     }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/LocationPermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/LocationPermissionHelper.kt
@@ -8,6 +8,7 @@ import platform.CoreLocation.CLLocationManagerDelegateProtocol
 import platform.CoreLocation.kCLAuthorizationStatusAuthorized
 import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
 import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+import platform.CoreLocation.kCLAuthorizationStatusDenied
 import platform.CoreLocation.kCLAuthorizationStatusNotDetermined
 import platform.darwin.NSObject
 
@@ -45,10 +46,13 @@ internal class LocationPermissionHelper : PermissionHelper {
                 PermissionStatus.Granted
 
             kCLAuthorizationStatusNotDetermined ->
+                PermissionStatus.Denied(shouldShowRationale = false)
+
+            kCLAuthorizationStatusDenied ->
                 PermissionStatus.Denied(shouldShowRationale = true)
 
             else ->
-                PermissionStatus.Denied(shouldShowRationale = false)
+                PermissionStatus.Denied(shouldShowRationale = true)
         }
         onPermissionResult(permissionStatus)
     }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/RemoteNotificationPermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/RemoteNotificationPermissionHelper.kt
@@ -8,6 +8,7 @@ import platform.UserNotifications.UNAuthorizationOptionSound
 import platform.UserNotifications.UNAuthorizationStatusAuthorized
 import platform.UserNotifications.UNAuthorizationStatusEphemeral
 import platform.UserNotifications.UNAuthorizationStatusNotDetermined
+import platform.UserNotifications.UNAuthorizationStatusDenied
 import platform.UserNotifications.UNAuthorizationStatusProvisional
 import platform.UserNotifications.UNUserNotificationCenter
 
@@ -45,10 +46,13 @@ internal class RemoteNotificationPermissionHelper : PermissionHelper {
                     onPermissionResult(PermissionStatus.Granted)
 
                 UNAuthorizationStatusNotDetermined ->
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
+
+                UNAuthorizationStatusDenied ->
                     onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
 
                 else ->
-                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = false))
+                    onPermissionResult(PermissionStatus.Denied(shouldShowRationale = true))
             }
         }
     }


### PR DESCRIPTION
Refs #229 

Isn't this how it should be done @MohamedRejeb ?

I'd like to test this in my project and therefore publish Calf to my local maven repository but this does not work:

`./gradlew publishToMavenLocal` fails with: `> Cannot perform signing task ':calf-core:signDesktopPublication' because it has no configured signatory`, do you have a solution for this?

-----

My use case is a map and a locate me button. In the beginning, nothing should happen. If the user clicks the locate me button, they should see the permission request. If they accept all fine. If they deny also fine, nothing should be shown. If they then however click again and the system does no longer display the dialog (because it has been denied), I want to show a dialog from which you can go to the settings. 

This behavior that I'm describing works already as is on Android. This is my code:

```
val permissionState = rememberPermissionState(Permission.FineLocation)
var hasRequestedLocation by rememberSaveable { mutableStateOf(value = false) }


LaunchedEffect(permissionState.status, hasRequestedLocation) {
  if (permissionState.status is PermissionStatus.Granted && hasRequestedLocation) {
    requestCurrentLocation()
  }
}

Button(
  onClick = {
    when (permissionState.status) {
      PermissionStatus.Granted -> requestCurrentLocation()
      is PermissionStatus.Denied -> when (permissionStatus.shouldShowRationale) {
        true -> permissionRationalDialog = true
        false -> {
          hasRequestedLocation = true
          permissionState.launchPermissionRequest()
        }
      }
    }
  },
)
```