### PR TITLE
Refactor: Handle Storage Permissions Based on Android API Level

### DIFF
--- a/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/PermissionsUtil.android.kt
+++ b/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/PermissionsUtil.android.kt
@@ -39,7 +39,7 @@ internal fun PermissionLifecycleCheckerEffect(
                 }
             }
         }
-    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val lifecycle = androidx.lifecycle.compose.LocalLifecycleOwner.current.lifecycle
     DisposableEffect(lifecycle, permissionCheckerObserver) {
         lifecycle.addObserver(permissionCheckerObserver)
         onDispose { lifecycle.removeObserver(permissionCheckerObserver) }
@@ -72,7 +72,7 @@ internal fun PermissionsLifecycleCheckerEffect(
                 }
             }
         }
-    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val lifecycle = androidx.lifecycle.compose.LocalLifecycleOwner.current.lifecycle
     DisposableEffect(lifecycle, permissionsCheckerObserver) {
         lifecycle.addObserver(permissionsCheckerObserver)
         onDispose { lifecycle.removeObserver(permissionsCheckerObserver) }
@@ -104,27 +104,36 @@ internal fun Permission.toAndroidPermission(): String {
     return when (this) {
         Permission.Call -> Manifest.permission.CALL_PHONE
         Permission.Camera -> Manifest.permission.CAMERA
-        Permission.Gallery -> Manifest.permission.READ_EXTERNAL_STORAGE
-        Permission.ReadStorage -> Manifest.permission.READ_EXTERNAL_STORAGE
-        Permission.WriteStorage -> Manifest.permission.WRITE_EXTERNAL_STORAGE
+        Permission.Gallery ->
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            else
+                ""
+        Permission.ReadStorage ->
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            else
+                ""
+        Permission.WriteStorage ->
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            else
+                ""
         Permission.ReadImage ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 Manifest.permission.READ_MEDIA_IMAGES
             else
                 ""
-
         Permission.ReadVideo ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 Manifest.permission.READ_MEDIA_VIDEO
             else
                 ""
-
         Permission.ReadAudio ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 Manifest.permission.READ_MEDIA_AUDIO
             else
                 ""
-
         Permission.FineLocation -> Manifest.permission.ACCESS_FINE_LOCATION
         Permission.CoarseLocation -> Manifest.permission.ACCESS_COARSE_LOCATION
         Permission.RemoteNotification -> Manifest.permission.RECEIVE_BOOT_COMPLETED
@@ -135,29 +144,26 @@ internal fun Permission.toAndroidPermission(): String {
                 Manifest.permission.BLUETOOTH_SCAN
             else
                 ""
-
         Permission.BluetoothConnect ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
                 Manifest.permission.BLUETOOTH_CONNECT
             else
                 ""
-
         Permission.BluetoothAdvertise ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
                 Manifest.permission.BLUETOOTH_ADVERTISE
             else
                 ""
-
         Permission.Notification ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 Manifest.permission.POST_NOTIFICATIONS
             else
                 ""
-
         Permission.ReadContacts -> Manifest.permission.READ_CONTACTS
         Permission.ReadCalendar -> Manifest.permission.READ_CALENDAR
         Permission.WriteCalendar -> Manifest.permission.WRITE_CALENDAR
     }
+
 }
 
 internal fun Permission.isAlwaysGranted(): Boolean =


### PR DESCRIPTION
-   Update `Gallery`, `ReadStorage`, and `WriteStorage` permissions to be API level-aware.
-   For `Gallery` and `ReadStorage`, only request `READ_EXTERNAL_STORAGE` on Android versions lower than API 33 (Tiramisu), and remove the permission on higher versions.
-   For `WriteStorage`, only request `WRITE_EXTERNAL_STORAGE` on Android versions lower than API 29 (Q), and remove the permission on higher versions.
- Corrected the missing last } in the original file.