### PR TITLE
Add Wi-Fi permissions

### DIFF
--- a/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/PermissionsUtil.android.kt
+++ b/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/PermissionsUtil.android.kt
@@ -176,6 +176,14 @@ internal fun Permission.toAndroidPermission(): String {
         Permission.ReadContacts -> Manifest.permission.READ_CONTACTS
         Permission.ReadCalendar -> Manifest.permission.READ_CALENDAR
         Permission.WriteCalendar -> Manifest.permission.WRITE_CALENDAR
+        Permission.WifiAccessState -> Manifest.permission.ACCESS_WIFI_STATE
+        Permission.WifiChangeState -> Manifest.permission.CHANGE_WIFI_STATE
+
+        Permission.WifiNearbyDevices ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                Manifest.permission.NEARBY_WIFI_DEVICES
+            else
+                ""
     }
 
 }
@@ -207,6 +215,9 @@ internal fun getPermissionFromAndroidPermission(androidPermission: String): Perm
         Manifest.permission.BLUETOOTH_CONNECT -> Permission.BluetoothConnect
         Manifest.permission.BLUETOOTH_ADVERTISE -> Permission.BluetoothAdvertise
         Manifest.permission.READ_CONTACTS -> Permission.ReadContacts
+        Manifest.permission.ACCESS_WIFI_STATE -> Permission.WifiAccessState
+        Manifest.permission.CHANGE_WIFI_STATE -> Permission.WifiChangeState
+        Manifest.permission.NEARBY_WIFI_DEVICES -> Permission.WifiNearbyDevices
         else -> null
     }
 }

--- a/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionState.kt
+++ b/calf-permissions/src/commonMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionState.kt
@@ -109,5 +109,8 @@ enum class Permission {
     BluetoothAdvertise,
     ReadContacts,
     ReadCalendar,
-    WriteCalendar
+    WriteCalendar,
+    WifiAccessState,
+    WifiChangeState,
+    WifiNearbyDevices
 }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionsUtil.ios.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionsUtil.ios.kt
@@ -10,6 +10,7 @@ import com.mohamedrejeb.calf.permissions.helper.LocalNotificationPermissionHelpe
 import com.mohamedrejeb.calf.permissions.helper.LocationPermissionHelper
 import com.mohamedrejeb.calf.permissions.helper.PermissionHelper
 import com.mohamedrejeb.calf.permissions.helper.RemoteNotificationPermissionHelper
+import com.mohamedrejeb.calf.permissions.helper.WifiPermissionHelper
 import platform.AVFoundation.AVMediaTypeAudio
 import platform.AVFoundation.AVMediaTypeVideo
 
@@ -56,5 +57,11 @@ internal fun Permission.getPermissionDelegate(): PermissionHelper {
         Permission.ReadContacts -> ContactPermissionHelper()
         Permission.ReadCalendar -> CalendarPermissionHelper()
         Permission.WriteCalendar -> CalendarPermissionHelper()
+
+        Permission.WifiAccessState,
+        Permission.WifiChangeState,
+        Permission.WifiNearbyDevices,
+            ->
+            WifiPermissionHelper()
     }
 }

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/WifiPermissionHelper.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/helper/WifiPermissionHelper.kt
@@ -1,0 +1,118 @@
+package com.mohamedrejeb.calf.permissions.helper
+
+import com.mohamedrejeb.calf.permissions.ExperimentalPermissionsApi
+import com.mohamedrejeb.calf.permissions.PermissionStatus
+import platform.Foundation.NSNetService
+import platform.Foundation.NSNetServiceDelegateProtocol
+import platform.Foundation.NSTimer
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationState.UIApplicationStateActive
+import platform.darwin.NSObject
+
+internal class WifiPermissionHelper : PermissionHelper {
+    private var currentPermissionDelegate: LocalNetworkPermissionDelegate? = null
+
+    override fun launchPermissionRequest(onPermissionResult: (Boolean) -> Unit) {
+        handleLaunchPermissionRequest(
+            onPermissionResult = onPermissionResult,
+            launchPermissionRequest = {
+                currentPermissionDelegate?.cancel()
+
+                val newDelegate = LocalNetworkPermissionDelegate { completedDelegate, granted ->
+                    onPermissionResult(granted)
+
+                    if (currentPermissionDelegate === completedDelegate) {
+                        currentPermissionDelegate = null
+                    }
+                }
+                currentPermissionDelegate = newDelegate
+                newDelegate.startCheck()
+            }
+        )
+    }
+
+    @OptIn(ExperimentalPermissionsApi::class)
+    override fun getPermissionStatus(onPermissionResult: (PermissionStatus) -> Unit) {
+        currentPermissionDelegate?.cancel()
+
+        val newDelegate = LocalNetworkPermissionDelegate { completedDelegate, granted ->
+            val status = if (granted) {
+                PermissionStatus.Granted
+            } else {
+                PermissionStatus.Denied(shouldShowRationale = true)
+            }
+
+            onPermissionResult(status)
+
+            if (currentPermissionDelegate === completedDelegate) {
+                currentPermissionDelegate = null
+            }
+        }
+        currentPermissionDelegate = newDelegate
+        newDelegate.startCheck()
+    }
+}
+
+/**
+ * Manages the NSNetService interaction to check/trigger local network permission.
+ */
+private class LocalNetworkPermissionDelegate(
+    private val onComplete: (delegate: LocalNetworkPermissionDelegate, granted: Boolean) -> Unit
+) : NSObject(), NSNetServiceDelegateProtocol {
+
+    private var netService: NSNetService? = null
+    private var timeoutTimer: NSTimer? = null
+    private var isCompleted = false
+
+    fun startCheck() {
+        if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
+            cleanupAndComplete(false)
+            return
+        }
+
+        netService = NSNetService(
+            domain = "local.",
+            type = "_lnp._tcp.",
+            name = "CalfWifiPermissionCheck",
+            port = 0
+        )
+        if (netService == null) {
+            cleanupAndComplete(false)
+            return
+        }
+
+        netService?.delegate = this
+        timeoutTimer = NSTimer.scheduledTimerWithTimeInterval(3.0, repeats = false) {
+            cleanupAndComplete(false)
+        }
+
+        netService?.publish()
+    }
+
+    private fun cleanupAndComplete(granted: Boolean) {
+        if (isCompleted) return
+
+        isCompleted = true
+        timeoutTimer?.invalidate()
+
+        timeoutTimer = null
+        netService?.stop()
+
+        netService?.delegate = null
+        netService = null
+
+        onComplete(this, granted)
+    }
+
+    override fun netServiceDidPublish(sender: NSNetService) {
+        cleanupAndComplete(true)
+    }
+
+    override fun netService(sender: NSNetService, didNotPublish: Map<Any?, *>) {
+        cleanupAndComplete(false)
+    }
+
+    fun cancel() {
+        cleanupAndComplete(false)
+    }
+}


### PR DESCRIPTION
Added support for Wi-Fi permissions.

On Android:
- `Manifest.permission.ACCESS_WIFI_STATE`,
- `Manifest.permission.CHANGE_WIFI_STATE`,
- `Manifest.permission.NEARBY_WIFI_DEVICES`.

On iOS:
- I believe first two don't have equivalents as iOS doesn't support Wi-Fi state changes by third-party apps,
- for the closest `NEARBY_WIFI_DEVICES` equivalent, I think `NSLocalNetworkUsageDescription` is the right thing and I tried to trigger local network access in `WifiPermissionHelper.kt`.

But please double-check this class and test the feature because I don't do iOS development and it's AI-enhanced :sweat_smile: 