### PR TITLE
fix: remove suffix from temp URL

### DIFF
--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/TempFile.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/TempFile.kt
@@ -14,7 +14,7 @@ internal fun NSURL.createTempFile(): NSURL? {
     val data = NSData.dataWithContentsOfURL(this)
         ?: absoluteURL?.dataRepresentation()
         ?: return null
-    return NSURL.fileURLWithPath("${NSTemporaryDirectory()}/${NSUUID().UUIDString}.$extension").apply {
+    return NSURL.fileURLWithPath("${NSTemporaryDirectory().removeSuffix("/")}/${NSUUID().UUIDString}.$extension").apply {
         data.writeToURL(this, true)
     }
 }


### PR DESCRIPTION
In my use case, I had to access tempFile, which has incorrect URL due to double slash (added by `NSTemporaryDirectory()`)