### PR TITLE
fix: properly handle live photos for iOS

### DIFF
--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
@@ -280,8 +280,10 @@ private fun createPHPickerViewController(
         FilePickerFileType.Image ->
             filterList.add(PHPickerFilter.imagesFilter())
 
-        FilePickerFileType.Video ->
+        FilePickerFileType.Video -> {
             filterList.add(PHPickerFilter.videosFilter())
+            filterList.add(PHPickerFilter.livePhotosFilter())
+        }
 
         else -> {
             filterList.add(PHPickerFilter.imagesFilter())

--- a/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
+++ b/calf-file-picker/src/iosMain/kotlin/com.mohamedrejeb.calf.picker/FilePickerLauncher.ios.kt
@@ -37,6 +37,7 @@ import platform.UniformTypeIdentifiers.UTTypeText
 import platform.UniformTypeIdentifiers.UTTypeVideo
 import platform.darwin.NSObject
 import kotlin.coroutines.resume
+import platform.UniformTypeIdentifiers.UTTypeMovie
 
 @OptIn(BetaInteropApi::class)
 @Composable
@@ -161,7 +162,7 @@ private fun rememberImageVideoPickerLauncher(
                             val result = it as? PHPickerResult ?: return@mapNotNull null
 
                             async {
-                                result.itemProvider.loadFileRepresentationForTypeIdentifierSuspend()
+                                result.itemProvider.loadFileRepresentationForTypeIdentifierSuspend(type)
                             }
                         }
                         .awaitAll()
@@ -200,10 +201,16 @@ private fun rememberImageVideoPickerLauncher(
 }
 
 @OptIn(InternalCalfApi::class)
-private suspend fun NSItemProvider.loadFileRepresentationForTypeIdentifierSuspend(): KmpFile? =
+private suspend fun NSItemProvider.loadFileRepresentationForTypeIdentifierSuspend(type: FilePickerFileType): KmpFile? =
     suspendCancellableCoroutine { continuation ->
+        val identifier = when(type) {
+            FilePickerFileType.Image -> UTTypeImage.identifier
+            FilePickerFileType.Video -> UTTypeMovie.identifier
+            else -> registeredTypeIdentifiers.firstOrNull() as? String ?: UTTypeImage.identifier
+        }
+
         val progress = loadFileRepresentationForTypeIdentifier(
-            typeIdentifier = registeredTypeIdentifiers.firstOrNull() as? String ?: UTTypeImage.identifier
+            typeIdentifier = identifier
         ) { url, error ->
             if (error != null) {
                 continuation.resume(null)


### PR DESCRIPTION
The changes selects correct UTType for file resolution, based on provided `FilePickerFileType` and allows to select live photos for `FilePickerFileType.Video`.

## Why

Current implementation picks type identifier from a selected file. For live photos it is `UTType.livePhotos`, which returns a `.pvt` file - a container for `.HEIC` and `.MOV`.

## The change

So when selecting a live photo, depending on `FilePickerFileType` you get different results:

- for `FilePickerFileType.Image`, a `UTType.Image` is selected, in order to correctly return a included .HEIC file
- for `FilePickerFileType.Video`, it selects `UTType.Movie`, returning `.MOV ` file.