### PR TITLE
Fix permission status refresh on lifecycle resume for iOS

### DIFF
--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.ios.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/MutablePermissionState.ios.kt
@@ -41,6 +41,9 @@ internal actual fun rememberMutablePermissionState(
             )
         }
 
+    // Refresh the permission status when the lifecycle is resumed
+    PermissionLifecycleCheckerEffect(permissionState)
+
     return permissionState
 }
 

--- a/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionsUtil.ios.kt
+++ b/calf-permissions/src/iosMain/kotlin/com.mohamedrejeb.calf/permissions/PermissionsUtil.ios.kt
@@ -1,5 +1,10 @@
 package com.mohamedrejeb.calf.permissions
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.mohamedrejeb.calf.permissions.helper.AVCapturePermissionHelper
 import com.mohamedrejeb.calf.permissions.helper.BluetoothPermissionHelper
 import com.mohamedrejeb.calf.permissions.helper.CalendarPermissionHelper
@@ -12,6 +17,70 @@ import com.mohamedrejeb.calf.permissions.helper.PermissionHelper
 import com.mohamedrejeb.calf.permissions.helper.RemoteNotificationPermissionHelper
 import platform.AVFoundation.AVMediaTypeAudio
 import platform.AVFoundation.AVMediaTypeVideo
+
+/**
+ * Effect that updates the `hasPermission` state of a revoked [MutablePermissionState] permission
+ * when the lifecycle gets called with [lifecycleEvent].
+ */
+@ExperimentalPermissionsApi
+@Composable
+internal fun PermissionLifecycleCheckerEffect(
+    permissionState: MutablePermissionState,
+    lifecycleEvent: Lifecycle.Event = Lifecycle.Event.ON_RESUME,
+) {
+    // Check if the permission was granted when the lifecycle is resumed.
+    // The user might've gone to the Settings screen and granted the permission.
+    val permissionCheckerObserver =
+        remember(permissionState) {
+            LifecycleEventObserver { _, event ->
+                if (event == lifecycleEvent) {
+                    // If the permission is revoked, check again.
+                    // We don't check if the permission was denied as that triggers a process restart.
+                    if (permissionState.status != PermissionStatus.Granted) {
+                        permissionState.refreshPermissionStatus()
+                    }
+                }
+            }
+        }
+    val lifecycle = androidx.lifecycle.compose.LocalLifecycleOwner.current.lifecycle
+    DisposableEffect(lifecycle, permissionCheckerObserver) {
+        lifecycle.addObserver(permissionCheckerObserver)
+        onDispose { lifecycle.removeObserver(permissionCheckerObserver) }
+    }
+}
+
+/**
+ * Effect that updates the `hasPermission` state of a list of permissions
+ * when the lifecycle gets called with [lifecycleEvent] and the permission is revoked.
+ */
+@ExperimentalPermissionsApi
+@Composable
+internal fun PermissionsLifecycleCheckerEffect(
+    permissions: List<MutablePermissionState>,
+    lifecycleEvent: Lifecycle.Event = Lifecycle.Event.ON_RESUME,
+) {
+    // Check if the permission was granted when the lifecycle is resumed.
+    // The user might've gone to the Settings screen and granted the permission.
+    val permissionsCheckerObserver =
+        remember(permissions) {
+            LifecycleEventObserver { _, event ->
+                if (event == lifecycleEvent) {
+                    for (permission in permissions) {
+                        // If the permission is revoked, check again. We don't check if the permission
+                        // was denied as that triggers a process restart.
+                        if (permission.status != PermissionStatus.Granted) {
+                            permission.refreshPermissionStatus()
+                        }
+                    }
+                }
+            }
+        }
+    val lifecycle = androidx.lifecycle.compose.LocalLifecycleOwner.current.lifecycle
+    DisposableEffect(lifecycle, permissionsCheckerObserver) {
+        lifecycle.addObserver(permissionsCheckerObserver)
+        onDispose { lifecycle.removeObserver(permissionsCheckerObserver) }
+    }
+}
 
 internal fun Permission.getPermissionDelegate(): PermissionHelper {
     return when (this) {


### PR DESCRIPTION
### What does this PR do?

This PR addresses a missing lifecycle effect for permission and multiple permission states specifically on the iOS target. Previously, the `LifecycleCheckerEffect` was not being applied in these scenarios, leading to potential issues with observing and reacting to permission changes throughout the app's lifecycle.

### Why is this change important?
I discovered this issue while integrating Calf `0.8.0` location permissions into my own project, where I observed that permission status updates weren't being correctly propagated across lifecycle changes on iOS. This behavior aligns with the existing discussion in [Issue #313](https://github.com/MohamedRejeb/Calf/issues/313), which this PR aims to resolve.

### Before & After

#### Before
https://github.com/user-attachments/assets/e7c93428-907d-4e8a-b69a-a0e612c75ca7

#### After
https://github.com/user-attachments/assets/d24fb81e-c91c-4d16-807b-7e3d7d4973ca

### Final note

Thank you, @MohamedRejeb , for creating and maintaining such an amazing and useful library! 🙌🏻 









