### PR TITLE
Add iosConfirmButtonIsPreferred parameter to AdaptiveAlertDialog

### DIFF
--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.kt
@@ -53,6 +53,9 @@ import com.mohamedrejeb.calf.ui.dialog.uikit.rememberAlertDialogIosProperties
  * @param iosDialogStyle The style of the iOS dialog.
  * @param iosConfirmButtonStyle The style of the iOS confirm button.
  * @param iosDismissButtonStyle The style of the iOS dismiss button.
+ * @param iosConfirmButtonIsPreferred Whether the confirm button is the preferred action on iOS.
+ * When true, the confirm button will be bold and triggered by the Enter key on a hardware keyboard.
+ * Only works with [AlertDialogIosStyle.Alert] style.
  * @param properties The properties of the dialog.
  */
 @Composable
@@ -79,6 +82,7 @@ expect fun AdaptiveAlertDialog(
     iosDialogStyle: AlertDialogIosStyle = AlertDialogIosStyle.Alert,
     iosConfirmButtonStyle: AlertDialogIosActionStyle = AlertDialogIosActionStyle.Default,
     iosDismissButtonStyle: AlertDialogIosActionStyle = AlertDialogIosActionStyle.Destructive,
+    iosConfirmButtonIsPreferred: Boolean = false,
 
     properties: DialogProperties = DialogProperties(),
     modifier: Modifier = Modifier,

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.ios.kt
@@ -39,6 +39,7 @@ actual fun AdaptiveAlertDialog(
     iosDialogStyle: AlertDialogIosStyle,
     iosConfirmButtonStyle: AlertDialogIosActionStyle,
     iosDismissButtonStyle: AlertDialogIosActionStyle,
+    iosConfirmButtonIsPreferred: Boolean,
     properties: DialogProperties,
     modifier: Modifier,
 ) {
@@ -54,6 +55,7 @@ actual fun AdaptiveAlertDialog(
                     title = confirmText,
                     style = iosConfirmButtonStyle,
                     onClick = onConfirm,
+                    isPreferred = iosConfirmButtonIsPreferred,
                 ),
                 AlertDialogIosAction(
                     title = dismissText,
@@ -83,6 +85,7 @@ actual fun AdaptiveAlertDialog(
         iosDialogStyle,
         iosConfirmButtonStyle,
         iosDismissButtonStyle,
+        iosConfirmButtonIsPreferred,
         properties,
     ) {
         alertDialogManager.onDismissRequest = onDismiss

--- a/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.material.kt
+++ b/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.material.kt
@@ -15,6 +15,7 @@ import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosActionStyle
 import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosProperties
 import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosStyle
 
+@Suppress("UNUSED_PARAMETER")
 @Composable
 actual fun AdaptiveAlertDialog(
     onConfirm: () -> Unit,
@@ -37,6 +38,7 @@ actual fun AdaptiveAlertDialog(
     iosDialogStyle: AlertDialogIosStyle,
     iosConfirmButtonStyle: AlertDialogIosActionStyle,
     iosDismissButtonStyle: AlertDialogIosActionStyle,
+    iosConfirmButtonIsPreferred: Boolean,
     properties: DialogProperties,
     modifier: Modifier,
 ) {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                 
Add `iosConfirmButtonIsPreferred` parameter to `AdaptiveAlertDialog` to expose the existing `isPreferred` functionality of `AlertDialogIosAction`.                                                                                               
                                                                                                                                                                                                                                                 
## Motivation                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                 
On iOS, `UIAlertController` supports `preferredAction` which makes a specific button bold/emphasized. This is useful for guiding users toward the recommended action (e.g., "Allow" button in a consent dialog).                                 
                                                                                                                                                                                                                                                 
The internal implementation already supports this via `AlertDialogIosAction.isPreferred`, but `AdaptiveAlertDialog` doesn't expose it as a parameter.                                                                                            
                                                                                                                                                                                                                                                 
## Changes                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                 
- Add `iosConfirmButtonIsPreferred: Boolean = false` parameter to `AdaptiveAlertDialog`                                                                                                                                                          
- Pass the value to `AlertDialogIosAction` on iOS implementation                                                                                                                                                                                 
- Non-iOS platforms ignore this parameter (iOS-specific feature)                                                                                                                                                                                 
                                                                                                                                                                                                                                                 
## Usage                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                 
```kotlin                                                                                                                                                                                                                                        
AdaptiveAlertDialog(                                                                                                                                                                                                                             
    onConfirm = { /* ... */ },                                                                                                                                                                                                                   
    onDismiss = { /* ... */ },                                                                                                                                                                                                                   
    confirmText = "Allow",                                                                                                                                                                                                                       
    dismissText = "Deny",                                                                                                                                                                                                                        
    title = "Permission",                                                                                                                                                                                                                        
    text = "Allow this action?",                                                                                                                                                                                                                 
    iosConfirmButtonIsPreferred = true  // Makes "Allow" button bold on iOS                                                                                                                                                                      
)                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                 
Additional Context                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                 
- Only works with .alert style (not .actionSheet) per Apple's documentation                                                                                                                                                                      
- Also enables keyboard shortcut (Enter key triggers the preferred action)                                                                                                                                                                       
- Reference: https://developer.apple.com/documentation/uikit/uialertcontroller/preferredaction   