### PR TITLE
Add an option to allow setting RepresentationModeCurrent on iOS file picker

### DIFF
--- a/calf-file-picker/src/androidMain/kotlin/com/mohamedrejeb/calf/picker/FilePickerLauncher.android.kt
+++ b/calf-file-picker/src/androidMain/kotlin/com/mohamedrejeb/calf/picker/FilePickerLauncher.android.kt
@@ -17,7 +17,7 @@ actual fun rememberFilePickerLauncher(
     return when (selectionMode) {
         FilePickerSelectionMode.Single -> {
             when (type) {
-                FilePickerFileType.Image, FilePickerFileType.Video, FilePickerFileType.ImageVideo ->
+                is FilePickerFileType.Image, FilePickerFileType.Video, FilePickerFileType.ImageVideo ->
                     pickSingleVisualMedia(
                         type = type,
                         onResult = onResult,
@@ -36,7 +36,7 @@ actual fun rememberFilePickerLauncher(
         }
         FilePickerSelectionMode.Multiple -> {
             when (type) {
-                FilePickerFileType.Image, FilePickerFileType.Video, FilePickerFileType.ImageVideo ->
+                is FilePickerFileType.Image, FilePickerFileType.Video, FilePickerFileType.ImageVideo ->
                     pickMultipleVisualMedia(
                         type = type,
                         onResult = onResult,
@@ -204,7 +204,7 @@ private fun pickFolder(
 
 internal fun FilePickerFileType.toPickVisualMediaRequest(): PickVisualMediaRequest {
     return when (this) {
-        FilePickerFileType.Image -> PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+        is FilePickerFileType.Image -> PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
         FilePickerFileType.Video -> PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.VideoOnly)
         else -> PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo)
     }
@@ -212,7 +212,7 @@ internal fun FilePickerFileType.toPickVisualMediaRequest(): PickVisualMediaReque
 
 internal fun FilePickerFileType.isVisualMedia(): Boolean {
     return when (this) {
-        FilePickerFileType.Image -> true
+        is FilePickerFileType.Image-> true
         FilePickerFileType.Video -> true
         FilePickerFileType.ImageVideo -> true
         else -> false

--- a/calf-file-picker/src/commonMain/kotlin/com.mohamedrejeb.calf/picker/FilePickerLauncher.kt
+++ b/calf-file-picker/src/commonMain/kotlin/com.mohamedrejeb.calf/picker/FilePickerLauncher.kt
@@ -11,7 +11,7 @@ expect fun rememberFilePickerLauncher(
 ): FilePickerLauncher
 
 sealed class FilePickerFileType(vararg val value: String) {
-    data object Image: FilePickerFileType(ImageContentType)
+    data class Image(val isCompat: Boolean = false): FilePickerFileType(ImageContentType)
     data object Video: FilePickerFileType(VideoContentType)
     data object ImageVideo: FilePickerFileType(ImageContentType, VideoContentType)
     data object Audio: FilePickerFileType(AudioContentType)

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/ImagePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/ImagePickerScreen.kt
@@ -44,7 +44,7 @@ fun ImagePickerScreen(navigateBack: () -> Unit) {
 
     val singlePickerLauncher =
         rememberFilePickerLauncher(
-            type = FilePickerFileType.Image,
+            type = FilePickerFileType.Image(),
             selectionMode = FilePickerSelectionMode.Single,
             onResult = {
                 files = it
@@ -53,7 +53,7 @@ fun ImagePickerScreen(navigateBack: () -> Unit) {
 
     val multiplePickerLauncher =
         rememberFilePickerLauncher(
-            type = FilePickerFileType.Image,
+            type = FilePickerFileType.Image(),
             selectionMode = FilePickerSelectionMode.Multiple,
             onResult = {
                 files = it


### PR DESCRIPTION
I need to call iOS file picker with this option: https://developer.apple.com/documentation/photosui/phpickerconfiguration-swift.struct/assetrepresentationmode/compatible
(basically because I need to handle the file with Skia and it [wont support HEIC](https://api.skia.org/classSkImage.html#:~:text=Encoded%20streams%20supported%20include%20BMP,%2C%20PNG%2C%20WBMP%2C%20WebP) which is very common on iOS)
I've added the parameter to `FilePickerFileType.Image` as that would modify the least amount of code in the library, but there are several other options available, like adding a new `ImageCompat` type for instance, or another API to allow for configuration of the underlying API.
Let me know what you think.