### PR TITLE
Fix IllegalArgumentException when requesting permissions with empty strings on Android 10

### DIFF
--- a/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/MutableMultiplePermissionsState.android.kt
+++ b/calf-permissions/src/androidMain/kotlin/com/mohamedrejeb/calf/permissions/MutableMultiplePermissionsState.android.kt
@@ -68,7 +68,7 @@ private fun rememberMutablePermissionsState(
     val context = LocalContext.current
     val activity = context.findActivity()
     val mutablePermissions = remember(permissions) {
-        return@remember permissions.map {  permission ->
+        return@remember permissions.map { permission ->
             MutablePermissionStateImpl(
                 permission,
                 context,
@@ -128,9 +128,15 @@ internal actual class MutableMultiplePermissionsState actual constructor(
     }
 
     actual override fun launchMultiplePermissionRequest() {
-        launcher?.launch(
-            permissions.map { it.permission.toAndroidPermission() }.toTypedArray()
-        ) ?: throw IllegalStateException("ActivityResultLauncher cannot be null")
+        // added empty string and empty array safeguards
+        val safePermissions = permissions
+            .map { it.permission.toAndroidPermission() }
+            .filter { it.isNotBlank() }
+
+        if (safePermissions.isNotEmpty()) {
+            launcher?.launch(safePermissions.toTypedArray())
+                ?: throw IllegalStateException("ActivityResultLauncher cannot be null")
+        }
     }
 
     internal var launcher: ActivityResultLauncher<Array<String>>? = null


### PR DESCRIPTION
# Fix crash when requesting multiple permissions on Android 10

## Summary
This PR resolves [issue #386](https://github.com/MohamedRejeb/Calf/issues/386), where requesting multiple permissions on **Android 10 (API 29)** caused an `IllegalArgumentException`.  
The crash was triggered because the permission array contained empty strings. The empty strings present in the multiple permissions array were causing the device to crash.

---

## Correction
The fix ensures that only valid permission strings are passed to the launcher. Empty strings are filtered and removed and safeguard for not passing empty array of permissions as well is added.

---

## Verification
- Tested on Android 10 emulator: Crash no longer occurs, dialogs appear sequentially as expected.

---

## Demonstration

| Before Fix | After Fix |
|------------|-----------|
| [![Before Fix](https://i.ytimg.com/vi/rnhI-aaBijc/oar2.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLBBHXa_MxIkyXxKS3mjntKPxRTy1w&usqp=CCk)](https://www.youtube.com/shorts/rnhI-aaBijc) | [![After Fix](https://i.ytimg.com/vi/_RHdGVyBvR0/oar2.jpg?sqp=-oaymwEoCJUDENAFSFqQAgHyq4qpAxcIARUAAIhC2AEB4gEKCBgQAhgGOAFAAQ==&rs=AOn4CLAA4XtlNYcUwohIA-07tn8dd2ynIg&usqp=CCk)](https://www.youtube.com/shorts/_RHdGVyBvR0) |
