### PR TITLE
Fix AdaptiveAlertDialog crashes on iOS

### DIFF
--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AlertDialogManager.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AlertDialogManager.kt
@@ -25,7 +25,7 @@ class AlertDialogManager internal constructor(
     internal var onDismissRequest: () -> Unit,
     internal var iosProperties: AlertDialogIosProperties,
     internal var properties: DialogProperties,
-) {
+) : NSObject() {
 
     /**
      * Indicates whether the dialog is presented or not.


### PR DESCRIPTION
Hi,
This PR fixes #381

For `@ObjCAction` methods to work, I think the class has to inherit from `NSObject`:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[ComposeApp_kobjcc0 dismiss]: unrecognized selector sent to instance 0x600000284680'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001804c9690 __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x00000001800937cc objc_exception_throw + 72
	2   CoreFoundation                      0x00000001804deea4 +[NSObject(NSObject) instanceMethodSignatureForSelector:] + 0
	…
```