### PR TITLE
Replace empty function bodies with `= Unit` in permission registratio…

### DIFF
--- a/calf-permissions/background-location/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/BackgroundLocationPermissions.desktop.kt
+++ b/calf-permissions/background-location/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/BackgroundLocationPermissions.desktop.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerBackgroundLocationPermission(permission: Permission) {}
+internal actual fun registerBackgroundLocationPermission(permission: Permission) = Unit

--- a/calf-permissions/background-location/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/BackgroundLocationPermissions.js.kt
+++ b/calf-permissions/background-location/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/BackgroundLocationPermissions.js.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerBackgroundLocationPermission(permission: Permission) {}
+internal actual fun registerBackgroundLocationPermission(permission: Permission) = Unit

--- a/calf-permissions/background-location/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/BackgroundLocationPermissions.wasmJs.kt
+++ b/calf-permissions/background-location/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/BackgroundLocationPermissions.wasmJs.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerBackgroundLocationPermission(permission: Permission) {}
+internal actual fun registerBackgroundLocationPermission(permission: Permission) = Unit

--- a/calf-permissions/bluetooth/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/BluetoothPermissions.desktop.kt
+++ b/calf-permissions/bluetooth/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/BluetoothPermissions.desktop.kt
@@ -1,9 +1,9 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerBluetoothLePermission(permission: Permission) {}
+internal actual fun registerBluetoothLePermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothScanPermission(permission: Permission) {}
+internal actual fun registerBluetoothScanPermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothConnectPermission(permission: Permission) {}
+internal actual fun registerBluetoothConnectPermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothAdvertisePermission(permission: Permission) {}
+internal actual fun registerBluetoothAdvertisePermission(permission: Permission) = Unit

--- a/calf-permissions/bluetooth/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/BluetoothPermissions.js.kt
+++ b/calf-permissions/bluetooth/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/BluetoothPermissions.js.kt
@@ -1,9 +1,9 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerBluetoothLePermission(permission: Permission) {}
+internal actual fun registerBluetoothLePermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothScanPermission(permission: Permission) {}
+internal actual fun registerBluetoothScanPermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothConnectPermission(permission: Permission) {}
+internal actual fun registerBluetoothConnectPermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothAdvertisePermission(permission: Permission) {}
+internal actual fun registerBluetoothAdvertisePermission(permission: Permission) = Unit

--- a/calf-permissions/bluetooth/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/BluetoothPermissions.wasmJs.kt
+++ b/calf-permissions/bluetooth/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/BluetoothPermissions.wasmJs.kt
@@ -1,9 +1,9 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerBluetoothLePermission(permission: Permission) {}
+internal actual fun registerBluetoothLePermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothScanPermission(permission: Permission) {}
+internal actual fun registerBluetoothScanPermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothConnectPermission(permission: Permission) {}
+internal actual fun registerBluetoothConnectPermission(permission: Permission) = Unit
 
-internal actual fun registerBluetoothAdvertisePermission(permission: Permission) {}
+internal actual fun registerBluetoothAdvertisePermission(permission: Permission) = Unit

--- a/calf-permissions/calendar/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/CalendarPermissions.desktop.kt
+++ b/calf-permissions/calendar/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/CalendarPermissions.desktop.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadCalendarPermission(permission: Permission) {}
+internal actual fun registerReadCalendarPermission(permission: Permission) = Unit
 
-internal actual fun registerWriteCalendarPermission(permission: Permission) {}
+internal actual fun registerWriteCalendarPermission(permission: Permission) = Unit

--- a/calf-permissions/calendar/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/CalendarPermissions.js.kt
+++ b/calf-permissions/calendar/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/CalendarPermissions.js.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadCalendarPermission(permission: Permission) {}
+internal actual fun registerReadCalendarPermission(permission: Permission) = Unit
 
-internal actual fun registerWriteCalendarPermission(permission: Permission) {}
+internal actual fun registerWriteCalendarPermission(permission: Permission) = Unit

--- a/calf-permissions/calendar/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/CalendarPermissions.wasmJs.kt
+++ b/calf-permissions/calendar/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/CalendarPermissions.wasmJs.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadCalendarPermission(permission: Permission) {}
+internal actual fun registerReadCalendarPermission(permission: Permission) = Unit
 
-internal actual fun registerWriteCalendarPermission(permission: Permission) {}
+internal actual fun registerWriteCalendarPermission(permission: Permission) = Unit

--- a/calf-permissions/camera/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/CameraPermissions.desktop.kt
+++ b/calf-permissions/camera/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/CameraPermissions.desktop.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerCameraPermission(permission: Permission) {}
+internal actual fun registerCameraPermission(permission: Permission) = Unit

--- a/calf-permissions/camera/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/CameraPermissions.js.kt
+++ b/calf-permissions/camera/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/CameraPermissions.js.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerCameraPermission(permission: Permission) {}
+internal actual fun registerCameraPermission(permission: Permission) = Unit

--- a/calf-permissions/camera/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/CameraPermissions.wasmJs.kt
+++ b/calf-permissions/camera/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/CameraPermissions.wasmJs.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerCameraPermission(permission: Permission) {}
+internal actual fun registerCameraPermission(permission: Permission) = Unit

--- a/calf-permissions/contacts/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/ContactPermissions.desktop.kt
+++ b/calf-permissions/contacts/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/ContactPermissions.desktop.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadContactsPermission(permission: Permission) {}
+internal actual fun registerReadContactsPermission(permission: Permission) = Unit
 
-internal actual fun registerWriteContactsPermission(permission: Permission) {}
+internal actual fun registerWriteContactsPermission(permission: Permission) = Unit

--- a/calf-permissions/contacts/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/ContactPermissions.js.kt
+++ b/calf-permissions/contacts/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/ContactPermissions.js.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadContactsPermission(permission: Permission) {}
+internal actual fun registerReadContactsPermission(permission: Permission) = Unit
 
-internal actual fun registerWriteContactsPermission(permission: Permission) {}
+internal actual fun registerWriteContactsPermission(permission: Permission) = Unit

--- a/calf-permissions/contacts/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/ContactPermissions.wasmJs.kt
+++ b/calf-permissions/contacts/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/ContactPermissions.wasmJs.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadContactsPermission(permission: Permission) {}
+internal actual fun registerReadContactsPermission(permission: Permission) = Unit
 
-internal actual fun registerWriteContactsPermission(permission: Permission) {}
+internal actual fun registerWriteContactsPermission(permission: Permission) = Unit

--- a/calf-permissions/core/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/StoragePermissions.desktop.kt
+++ b/calf-permissions/core/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/StoragePermissions.desktop.kt
@@ -1,9 +1,9 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadStoragePermission(permission: Permission) {}
+internal actual fun registerReadStoragePermission(permission: Permission) = Unit
 
-internal actual fun registerWriteStoragePermission(permission: Permission) {}
+internal actual fun registerWriteStoragePermission(permission: Permission) = Unit
 
-internal actual fun registerReadAudioPermission(permission: Permission) {}
+internal actual fun registerReadAudioPermission(permission: Permission) = Unit
 
-internal actual fun registerCallPermission(permission: Permission) {}
+internal actual fun registerCallPermission(permission: Permission) = Unit

--- a/calf-permissions/core/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/StoragePermissions.js.kt
+++ b/calf-permissions/core/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/StoragePermissions.js.kt
@@ -1,9 +1,9 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadStoragePermission(permission: Permission) {}
+internal actual fun registerReadStoragePermission(permission: Permission) = Unit
 
-internal actual fun registerWriteStoragePermission(permission: Permission) {}
+internal actual fun registerWriteStoragePermission(permission: Permission) = Unit
 
-internal actual fun registerReadAudioPermission(permission: Permission) {}
+internal actual fun registerReadAudioPermission(permission: Permission) = Unit
 
-internal actual fun registerCallPermission(permission: Permission) {}
+internal actual fun registerCallPermission(permission: Permission) = Unit

--- a/calf-permissions/core/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/StoragePermissions.wasmJs.kt
+++ b/calf-permissions/core/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/StoragePermissions.wasmJs.kt
@@ -1,9 +1,9 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerReadStoragePermission(permission: Permission) {}
+internal actual fun registerReadStoragePermission(permission: Permission) = Unit
 
-internal actual fun registerWriteStoragePermission(permission: Permission) {}
+internal actual fun registerWriteStoragePermission(permission: Permission) = Unit
 
-internal actual fun registerReadAudioPermission(permission: Permission) {}
+internal actual fun registerReadAudioPermission(permission: Permission) = Unit
 
-internal actual fun registerCallPermission(permission: Permission) {}
+internal actual fun registerCallPermission(permission: Permission) = Unit

--- a/calf-permissions/gallery/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/GalleryPermissions.desktop.kt
+++ b/calf-permissions/gallery/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/GalleryPermissions.desktop.kt
@@ -1,7 +1,7 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerGalleryPermission(permission: Permission) {}
+internal actual fun registerGalleryPermission(permission: Permission) = Unit
 
-internal actual fun registerReadImagePermission(permission: Permission) {}
+internal actual fun registerReadImagePermission(permission: Permission) = Unit
 
-internal actual fun registerReadVideoPermission(permission: Permission) {}
+internal actual fun registerReadVideoPermission(permission: Permission) = Unit

--- a/calf-permissions/gallery/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/GalleryPermissions.js.kt
+++ b/calf-permissions/gallery/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/GalleryPermissions.js.kt
@@ -1,7 +1,7 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerGalleryPermission(permission: Permission) {}
+internal actual fun registerGalleryPermission(permission: Permission) = Unit
 
-internal actual fun registerReadImagePermission(permission: Permission) {}
+internal actual fun registerReadImagePermission(permission: Permission) = Unit
 
-internal actual fun registerReadVideoPermission(permission: Permission) {}
+internal actual fun registerReadVideoPermission(permission: Permission) = Unit

--- a/calf-permissions/gallery/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/GalleryPermissions.wasmJs.kt
+++ b/calf-permissions/gallery/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/GalleryPermissions.wasmJs.kt
@@ -1,7 +1,7 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerGalleryPermission(permission: Permission) {}
+internal actual fun registerGalleryPermission(permission: Permission) = Unit
 
-internal actual fun registerReadImagePermission(permission: Permission) {}
+internal actual fun registerReadImagePermission(permission: Permission) = Unit
 
-internal actual fun registerReadVideoPermission(permission: Permission) {}
+internal actual fun registerReadVideoPermission(permission: Permission) = Unit

--- a/calf-permissions/location/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/LocationPermissions.desktop.kt
+++ b/calf-permissions/location/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/LocationPermissions.desktop.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerFineLocationPermission(permission: Permission) {}
+internal actual fun registerFineLocationPermission(permission: Permission) = Unit
 
-internal actual fun registerCoarseLocationPermission(permission: Permission) {}
+internal actual fun registerCoarseLocationPermission(permission: Permission) = Unit

--- a/calf-permissions/location/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/LocationPermissions.js.kt
+++ b/calf-permissions/location/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/LocationPermissions.js.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerFineLocationPermission(permission: Permission) {}
+internal actual fun registerFineLocationPermission(permission: Permission) = Unit
 
-internal actual fun registerCoarseLocationPermission(permission: Permission) {}
+internal actual fun registerCoarseLocationPermission(permission: Permission) = Unit

--- a/calf-permissions/location/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/LocationPermissions.wasmJs.kt
+++ b/calf-permissions/location/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/LocationPermissions.wasmJs.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerFineLocationPermission(permission: Permission) {}
+internal actual fun registerFineLocationPermission(permission: Permission) = Unit
 
-internal actual fun registerCoarseLocationPermission(permission: Permission) {}
+internal actual fun registerCoarseLocationPermission(permission: Permission) = Unit

--- a/calf-permissions/microphone/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/MicrophonePermissions.desktop.kt
+++ b/calf-permissions/microphone/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/MicrophonePermissions.desktop.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerRecordAudioPermission(permission: Permission) {}
+internal actual fun registerRecordAudioPermission(permission: Permission) = Unit

--- a/calf-permissions/microphone/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/MicrophonePermissions.js.kt
+++ b/calf-permissions/microphone/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/MicrophonePermissions.js.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerRecordAudioPermission(permission: Permission) {}
+internal actual fun registerRecordAudioPermission(permission: Permission) = Unit

--- a/calf-permissions/microphone/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/MicrophonePermissions.wasmJs.kt
+++ b/calf-permissions/microphone/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/MicrophonePermissions.wasmJs.kt
@@ -1,3 +1,3 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerRecordAudioPermission(permission: Permission) {}
+internal actual fun registerRecordAudioPermission(permission: Permission) = Unit

--- a/calf-permissions/notifications/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/NotificationPermissions.desktop.kt
+++ b/calf-permissions/notifications/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/NotificationPermissions.desktop.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerNotificationPermission(permission: Permission) {}
+internal actual fun registerNotificationPermission(permission: Permission) = Unit
 
-internal actual fun registerRemoteNotificationPermission(permission: Permission) {}
+internal actual fun registerRemoteNotificationPermission(permission: Permission) = Unit

--- a/calf-permissions/notifications/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/NotificationPermissions.js.kt
+++ b/calf-permissions/notifications/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/NotificationPermissions.js.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerNotificationPermission(permission: Permission) {}
+internal actual fun registerNotificationPermission(permission: Permission) = Unit
 
-internal actual fun registerRemoteNotificationPermission(permission: Permission) {}
+internal actual fun registerRemoteNotificationPermission(permission: Permission) = Unit

--- a/calf-permissions/notifications/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/NotificationPermissions.wasmJs.kt
+++ b/calf-permissions/notifications/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/NotificationPermissions.wasmJs.kt
@@ -1,5 +1,5 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerNotificationPermission(permission: Permission) {}
+internal actual fun registerNotificationPermission(permission: Permission) = Unit
 
-internal actual fun registerRemoteNotificationPermission(permission: Permission) {}
+internal actual fun registerRemoteNotificationPermission(permission: Permission) = Unit

--- a/calf-permissions/wifi/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/WifiPermissions.desktop.kt
+++ b/calf-permissions/wifi/src/desktopMain/kotlin/com/mohamedrejeb/calf/permissions/WifiPermissions.desktop.kt
@@ -1,7 +1,7 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerWifiAccessStatePermission(permission: Permission) {}
+internal actual fun registerWifiAccessStatePermission(permission: Permission) = Unit
 
-internal actual fun registerWifiChangeStatePermission(permission: Permission) {}
+internal actual fun registerWifiChangeStatePermission(permission: Permission) = Unit
 
-internal actual fun registerWifiNearbyDevicesPermission(permission: Permission) {}
+internal actual fun registerWifiNearbyDevicesPermission(permission: Permission) = Unit

--- a/calf-permissions/wifi/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/WifiPermissions.js.kt
+++ b/calf-permissions/wifi/src/jsMain/kotlin/com.mohamedrejeb.calf/permissions/WifiPermissions.js.kt
@@ -1,7 +1,7 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerWifiAccessStatePermission(permission: Permission) {}
+internal actual fun registerWifiAccessStatePermission(permission: Permission) = Unit
 
-internal actual fun registerWifiChangeStatePermission(permission: Permission) {}
+internal actual fun registerWifiChangeStatePermission(permission: Permission) = Unit
 
-internal actual fun registerWifiNearbyDevicesPermission(permission: Permission) {}
+internal actual fun registerWifiNearbyDevicesPermission(permission: Permission) = Unit

--- a/calf-permissions/wifi/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/WifiPermissions.wasmJs.kt
+++ b/calf-permissions/wifi/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/permissions/WifiPermissions.wasmJs.kt
@@ -1,7 +1,7 @@
 package com.mohamedrejeb.calf.permissions
 
-internal actual fun registerWifiAccessStatePermission(permission: Permission) {}
+internal actual fun registerWifiAccessStatePermission(permission: Permission) = Unit
 
-internal actual fun registerWifiChangeStatePermission(permission: Permission) {}
+internal actual fun registerWifiChangeStatePermission(permission: Permission) = Unit
 
-internal actual fun registerWifiNearbyDevicesPermission(permission: Permission) {}
+internal actual fun registerWifiNearbyDevicesPermission(permission: Permission) = Unit


### PR DESCRIPTION
…n functions across Desktop, JS, and WasmJs targets