### PR TITLE
Add cross-platform `CookieManager` to `WebView`

### DIFF
--- a/calf-webview/src/androidMain/kotlin/com/mohamedrejeb/calf/ui/web/CookieManager.android.kt
+++ b/calf-webview/src/androidMain/kotlin/com/mohamedrejeb/calf/ui/web/CookieManager.android.kt
@@ -1,0 +1,99 @@
+package com.mohamedrejeb.calf.ui.web
+
+import android.webkit.CookieManager as AndroidCookieManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+
+/**
+ * Android implementation of [CookieManager] using [android.webkit.CookieManager].
+ */
+public actual class CookieManager actual constructor() {
+
+    private val cookieManager: AndroidCookieManager
+        get() = AndroidCookieManager.getInstance()
+
+    /**
+     * Sets a cookie for the given URL.
+     *
+     * The cookie is converted to a Set-Cookie header string and passed to
+     * [AndroidCookieManager.setCookie].
+     *
+     * @param url The URL for which the cookie is to be set.
+     * @param cookie The [Cookie] to set.
+     */
+    public actual suspend fun setCookie(url: String, cookie: Cookie) {
+        withContext(Dispatchers.Main) {
+            val cookieString = buildCookieString(cookie)
+            suspendCancellableCoroutine { continuation ->
+                cookieManager.setCookie(url, cookieString) {
+                    continuation.resume(Unit)
+                }
+            }
+            cookieManager.flush()
+        }
+    }
+
+    /**
+     * Gets all cookies for the given URL.
+     *
+     * @param url The URL for which cookies are to be retrieved.
+     * @return A list of [Cookie] objects associated with the URL.
+     */
+    public actual suspend fun getCookies(url: String): List<Cookie> {
+        return withContext(Dispatchers.Main) {
+            val cookieString = cookieManager.getCookie(url) ?: return@withContext emptyList()
+            parseCookies(cookieString)
+        }
+    }
+
+    /**
+     * Removes all cookies.
+     */
+    public actual suspend fun removeAllCookies() {
+        withContext(Dispatchers.Main) {
+            suspendCancellableCoroutine { continuation ->
+                cookieManager.removeAllCookies {
+                    continuation.resume(Unit)
+                }
+            }
+            cookieManager.flush()
+        }
+    }
+}
+
+/**
+ * Builds a Set-Cookie header string from a [Cookie] object.
+ */
+private fun buildCookieString(cookie: Cookie): String = buildString {
+    append("${cookie.name}=${cookie.value}")
+    cookie.domain?.let { append("; Domain=$it") }
+    cookie.path?.let { append("; Path=$it") }
+    cookie.expiresDate?.let { append("; Max-Age=${(it - System.currentTimeMillis()) / 1000}") }
+    if (cookie.isSecure) append("; Secure")
+    if (cookie.isHttpOnly) append("; HttpOnly")
+}
+
+/**
+ * Parses a cookie header string (as returned by [AndroidCookieManager.getCookie])
+ * into a list of [Cookie] objects.
+ *
+ * The cookie string format is "name1=value1; name2=value2; ...".
+ */
+private fun parseCookies(cookieString: String): List<Cookie> {
+    println("cookieString: $cookieString")
+    return cookieString.split(";")
+        .mapNotNull { part ->
+            val trimmed = part.trim()
+            val equalsIndex = trimmed.indexOf('=')
+            if (equalsIndex > 0) {
+                Cookie(
+                    name = trimmed.substring(0, equalsIndex),
+                    value = trimmed.substring(equalsIndex + 1),
+                )
+            } else {
+                null
+            }
+        }
+}

--- a/calf-webview/src/androidMain/kotlin/com/mohamedrejeb/calf/ui/web/WebView.android.kt
+++ b/calf-webview/src/androidMain/kotlin/com/mohamedrejeb/calf/ui/web/WebView.android.kt
@@ -380,6 +380,8 @@ actual class WebViewState actual constructor(webContent: WebContent) {
         }
     )
 
+    actual val cookieManager: CookieManager = CookieManager()
+
     private fun applySettings() {
         webView?.applySettings(settings)
     }

--- a/calf-webview/src/commonMain/kotlin/com.mohamedrejeb.calf/ui/web/Cookie.kt
+++ b/calf-webview/src/commonMain/kotlin/com.mohamedrejeb.calf/ui/web/Cookie.kt
@@ -1,0 +1,23 @@
+package com.mohamedrejeb.calf.ui.web
+
+/**
+ * Represents an HTTP cookie.
+ *
+ * @param name The name of the cookie.
+ * @param value The value of the cookie.
+ * @param domain The domain for which the cookie is valid.
+ * @param path The path for which the cookie is valid.
+ * @param expiresDate The expiration date of the cookie in milliseconds since epoch.
+ *                    If null, the cookie is a session cookie.
+ * @param isSecure Whether the cookie should only be sent over secure (HTTPS) connections.
+ * @param isHttpOnly Whether the cookie is HTTP-only (not accessible via JavaScript).
+ */
+public data class Cookie(
+    val name: String,
+    val value: String,
+    val domain: String? = null,
+    val path: String? = null,
+    val expiresDate: Long? = null,
+    val isSecure: Boolean = false,
+    val isHttpOnly: Boolean = false,
+)

--- a/calf-webview/src/commonMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.kt
+++ b/calf-webview/src/commonMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.kt
@@ -1,0 +1,33 @@
+package com.mohamedrejeb.calf.ui.web
+
+/**
+ * A cross-platform cookie manager for managing cookies in the WebView.
+ *
+ * Each platform wraps its native cookie management API:
+ * - Android: `android.webkit.CookieManager`
+ * - iOS: `WKHTTPCookieStore`
+ * - Desktop: `java.net.CookieManager` (used by JavaFX WebEngine)
+ * - JS/WasmJS: No-op (not yet implemented)
+ */
+public expect class CookieManager() {
+    /**
+     * Sets a cookie for the given URL.
+     *
+     * @param url The URL for which the cookie is to be set.
+     * @param cookie The [Cookie] to set.
+     */
+    public suspend fun setCookie(url: String, cookie: Cookie)
+
+    /**
+     * Gets all cookies for the given URL.
+     *
+     * @param url The URL for which cookies are to be retrieved.
+     * @return A list of [Cookie] objects associated with the URL.
+     */
+    public suspend fun getCookies(url: String): List<Cookie>
+
+    /**
+     * Removes all cookies.
+     */
+    public suspend fun removeAllCookies()
+}

--- a/calf-webview/src/commonMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.kt
+++ b/calf-webview/src/commonMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.kt
@@ -123,6 +123,11 @@ expect class WebViewState(webContent: WebContent) {
 
     public val settings: WebSettings
 
+    /**
+     * The cookie manager for managing cookies in the WebView.
+     */
+    public val cookieManager: CookieManager
+
     public fun evaluateJavascript(script: String, callback: ((String?) -> Unit)? = null)
 }
 

--- a/calf-webview/src/desktopMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.desktop.kt
+++ b/calf-webview/src/desktopMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.desktop.kt
@@ -1,0 +1,64 @@
+package com.mohamedrejeb.calf.ui.web
+
+import java.net.CookieHandler
+import java.net.HttpCookie
+import java.net.URI
+
+/**
+ * Desktop implementation of [CookieManager].
+ * Uses [java.net.CookieManager] which is the cookie store used by JavaFX WebEngine.
+ */
+public actual class CookieManager actual constructor() {
+
+    private val cookieManager: java.net.CookieManager
+        get() {
+            val handler = CookieHandler.getDefault()
+            if (handler is java.net.CookieManager) return handler
+            // Install a default CookieManager if none is set
+            val newManager = java.net.CookieManager()
+            CookieHandler.setDefault(newManager)
+            return newManager
+        }
+
+    public actual suspend fun setCookie(url: String, cookie: Cookie) {
+        val uri = URI(url)
+        val httpCookie = HttpCookie(cookie.name, cookie.value).apply {
+            domain = cookie.domain ?: uri.host
+            path = cookie.path ?: "/"
+            secure = cookie.isSecure
+            isHttpOnly = cookie.isHttpOnly
+            if (cookie.expiresDate != null) {
+                val nowSeconds = System.currentTimeMillis() / 1000
+                val expiresSeconds = cookie.expiresDate / 1000
+                maxAge = (expiresSeconds - nowSeconds).coerceAtLeast(0)
+            } else {
+                // Session cookie — expires when the JVM exits
+                maxAge = -1
+            }
+        }
+        cookieManager.cookieStore.add(uri, httpCookie)
+    }
+
+    public actual suspend fun getCookies(url: String): List<Cookie> {
+        val uri = URI(url)
+        return cookieManager.cookieStore.get(uri).map { httpCookie ->
+            Cookie(
+                name = httpCookie.name,
+                value = httpCookie.value,
+                domain = httpCookie.domain,
+                path = httpCookie.path,
+                expiresDate = if (httpCookie.maxAge > 0) {
+                    System.currentTimeMillis() + httpCookie.maxAge * 1000
+                } else {
+                    null
+                },
+                isSecure = httpCookie.secure,
+                isHttpOnly = httpCookie.isHttpOnly,
+            )
+        }
+    }
+
+    public actual suspend fun removeAllCookies() {
+        cookieManager.cookieStore.removeAll()
+    }
+}

--- a/calf-webview/src/desktopMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.desktop.kt
+++ b/calf-webview/src/desktopMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.desktop.kt
@@ -153,6 +153,8 @@ actual class WebViewState actual constructor(webContent: WebContent) {
         }
     )
 
+    actual val cookieManager: CookieManager = CookieManager()
+
     private fun applySetting() {
         webView?.applySettings(settings)
     }

--- a/calf-webview/src/iosMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.ios.kt
+++ b/calf-webview/src/iosMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.ios.kt
@@ -1,0 +1,125 @@
+package com.mohamedrejeb.calf.ui.web
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.Foundation.NSDate
+import platform.Foundation.NSHTTPCookie
+import platform.Foundation.NSHTTPCookieDomain
+import platform.Foundation.NSHTTPCookieExpires
+import platform.Foundation.NSHTTPCookieName
+import platform.Foundation.NSHTTPCookiePath
+import platform.Foundation.NSHTTPCookieSecure
+import platform.Foundation.NSHTTPCookieValue
+import platform.Foundation.NSURL
+import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.timeIntervalSince1970
+import platform.WebKit.WKHTTPCookieStore
+import platform.WebKit.WKWebsiteDataStore
+import kotlin.coroutines.resume
+
+/**
+ * iOS implementation of [CookieManager] using [WKHTTPCookieStore].
+ *
+ * Uses the default [WKWebsiteDataStore]'s HTTP cookie store to manage cookies.
+ */
+public actual class CookieManager actual constructor() {
+
+    private val httpCookieStore: WKHTTPCookieStore
+        get() = WKWebsiteDataStore.defaultDataStore().httpCookieStore
+
+    /**
+     * Sets a cookie for the given URL using [WKHTTPCookieStore.setCookie].
+     *
+     * @param url The URL for which the cookie is to be set.
+     * @param cookie The [Cookie] to set.
+     */
+    public actual suspend fun setCookie(url: String, cookie: Cookie) {
+        val properties = mutableMapOf<Any?, Any?>()
+        properties[NSHTTPCookieName] = cookie.name
+        properties[NSHTTPCookieValue] = cookie.value
+        properties[NSHTTPCookiePath] = cookie.path ?: "/"
+
+        val domain = cookie.domain ?: NSURL(string = url).host
+        if (domain != null) {
+            properties[NSHTTPCookieDomain] = domain
+        }
+
+        cookie.expiresDate?.let {
+            val nsDate = NSDate.dateWithTimeIntervalSince1970(it / 1000.0)
+            properties[NSHTTPCookieExpires] = nsDate
+        }
+
+        if (cookie.isSecure) {
+            properties[NSHTTPCookieSecure] = "TRUE"
+        }
+
+        if (cookie.isHttpOnly) {
+            properties["HttpOnly"] = "TRUE"
+        }
+
+        val nsCookie = NSHTTPCookie.cookieWithProperties(properties) ?: return
+
+        suspendCancellableCoroutine { continuation ->
+            httpCookieStore.setCookie(nsCookie) {
+                continuation.resume(Unit)
+            }
+        }
+    }
+
+    /**
+     * Gets all cookies matching the given URL's domain from [WKHTTPCookieStore].
+     *
+     * @param url The URL for which cookies are to be retrieved.
+     * @return A list of [Cookie] objects associated with the URL.
+     */
+    @Suppress("UNCHECKED_CAST")
+    public actual suspend fun getCookies(url: String): List<Cookie> {
+        val nsUrl = NSURL(string = url)
+        val host = nsUrl.host ?: return emptyList()
+
+        val allCookies = suspendCancellableCoroutine { continuation ->
+            httpCookieStore.getAllCookies { cookies ->
+                continuation.resume(cookies as? List<NSHTTPCookie> ?: emptyList())
+            }
+        }
+
+        return allCookies
+            .filter { nsCookie ->
+                val cookieDomain = nsCookie.domain
+                host == cookieDomain ||
+                    host.endsWith(".$cookieDomain") ||
+                    (cookieDomain.startsWith(".") && host.endsWith(cookieDomain)) ||
+                    (cookieDomain.startsWith(".") && host == cookieDomain.removePrefix("."))
+            }
+            .map { nsCookie ->
+                Cookie(
+                    name = nsCookie.name,
+                    value = nsCookie.value,
+                    domain = nsCookie.domain,
+                    path = nsCookie.path,
+                    expiresDate = nsCookie.expiresDate?.timeIntervalSince1970?.let { (it * 1000).toLong() },
+                    isSecure = nsCookie.isSecure(),
+                    isHttpOnly = nsCookie.isHTTPOnly(),
+                )
+            }
+    }
+
+    /**
+     * Removes all cookies from [WKHTTPCookieStore].
+     */
+    @Suppress("UNCHECKED_CAST")
+    public actual suspend fun removeAllCookies() {
+        val allCookies = suspendCancellableCoroutine { continuation ->
+            httpCookieStore.getAllCookies { cookies ->
+                continuation.resume(cookies as? List<NSHTTPCookie> ?: emptyList())
+            }
+        }
+
+        allCookies.forEach { nsCookie ->
+            suspendCancellableCoroutine { continuation ->
+                httpCookieStore.deleteCookie(nsCookie) {
+                    continuation.resume(Unit)
+                }
+            }
+        }
+    }
+}

--- a/calf-webview/src/iosMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.ios.kt
+++ b/calf-webview/src/iosMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.ios.kt
@@ -156,6 +156,8 @@ actual class WebViewState actual constructor(
         }
     )
 
+    actual val cookieManager: CookieManager = CookieManager()
+
     private fun applySetting() {
         webView?.applySettings(settings)
     }

--- a/calf-webview/src/jsMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.js.kt
+++ b/calf-webview/src/jsMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.js.kt
@@ -1,0 +1,13 @@
+package com.mohamedrejeb.calf.ui.web
+
+/**
+ * JS implementation of [CookieManager].
+ * Not yet implemented — all methods are no-ops.
+ */
+public actual class CookieManager actual constructor() {
+    public actual suspend fun setCookie(url: String, cookie: Cookie) {}
+
+    public actual suspend fun getCookies(url: String): List<Cookie> = emptyList()
+
+    public actual suspend fun removeAllCookies() {}
+}

--- a/calf-webview/src/jsMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.js.kt
+++ b/calf-webview/src/jsMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.js.kt
@@ -84,6 +84,8 @@ actual class WebViewState actual constructor(webContent: WebContent) {
         onSettingsChanged = {}
     )
 
+    actual val cookieManager: CookieManager = CookieManager()
+
     actual fun evaluateJavascript(script: String, callback: ((String?) -> Unit)?) {}
 }
 

--- a/calf-webview/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.wasmJs.kt
+++ b/calf-webview/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/ui/web/CookieManager.wasmJs.kt
@@ -1,0 +1,13 @@
+package com.mohamedrejeb.calf.ui.web
+
+/**
+ * WasmJS implementation of [CookieManager].
+ * Not yet implemented — all methods are no-ops.
+ */
+public actual class CookieManager actual constructor() {
+    public actual suspend fun setCookie(url: String, cookie: Cookie) {}
+
+    public actual suspend fun getCookies(url: String): List<Cookie> = emptyList()
+
+    public actual suspend fun removeAllCookies() {}
+}

--- a/calf-webview/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.wasmJs.kt
+++ b/calf-webview/src/wasmJsMain/kotlin/com.mohamedrejeb.calf/ui/web/WebView.wasmJs.kt
@@ -84,6 +84,8 @@ actual class WebViewState actual constructor(webContent: WebContent) {
         onSettingsChanged = {}
     )
 
+    actual val cookieManager: CookieManager = CookieManager()
+
     actual fun evaluateJavascript(script: String, callback: ((String?) -> Unit)?) {}
 }
 

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/WebViewScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/WebViewScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.mohamedrejeb.calf.sample.navigation.Screen
+import com.mohamedrejeb.calf.ui.web.Cookie
 import com.mohamedrejeb.calf.ui.web.WebView
 import com.mohamedrejeb.calf.ui.web.rememberWebViewState
 
@@ -68,6 +69,24 @@ fun WebViewScreen(
                     androidSettings.supportZoom = true
                 }
 
+                // Access the cookie manager from the WebView state
+                val cookieManager = state.cookieManager
+                val testUrl = "https://github.com"
+
+                // Set a test cookie
+                cookieManager.setCookie(
+                    url = testUrl,
+                    cookie = Cookie(
+                        name = "test_session",
+                        value = "abc123",
+                    )
+                )
+
+                // Read cookies back to verify they were set
+                val cookiesAfterSet = cookieManager.getCookies(testUrl)
+                println("Cookies after setCookie: $cookiesAfterSet")
+
+                // Evaluate JavaScript
                 state.evaluateJavascript(
                     """
                         "Hello World!";


### PR DESCRIPTION
Fixes: #240 

Introduces a `CookieManager` API to manage HTTP cookies across Android, iOS, and Desktop platforms.

- Added `Cookie` data class to represent cookie properties.
- Added `CookieManager` expect class with `setCookie`, `getCookies`, and `removeAllCookies` methods.
- Implemented `CookieManager` for Android using `android.webkit.CookieManager`.
- Implemented `CookieManager` for iOS using `WKHTTPCookieStore`.
- Implemented `CookieManager` for Desktop using `java.net.CookieManager`.
- Added no-op `CookieManager` implementations for JS and WasmJS.
- Exposed `cookieManager` through the `WebView` interface and its platform-specific implementations.
- Updated the sample `WebViewScreen` to demonstrate cookie management.