### PR TITLE
Remove redundant branch input from Netlify workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -5,10 +5,6 @@ on:
     types:
       [ published ]
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to deploy'
-        required: true
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
### Summary
This PR cleans up the Netlify deployment workflow by removing the redundant `branch` input from the `workflow_dispatch` trigger.

### Context
In [PR #439](https://github.com/MohamedRejeb/Calf/pull/439), we added a manual `branch` input.  
After merging, it was noted that GitHub already provides a branch selector in the **Run workflow** dialog, so this input was unnecessary.

### Changes
- Removed the manual `branch` input from the workflow.
- Workflow now relies solely on GitHub’s built‑in branch selector.

### Impact
- Maintainers can trigger deployments directly from the branch dropdown in the Actions UI.
- No functional changes to the deployment process — just a simpler, cleaner workflow definition.

### Motivation
This follow‑up PR addresses feedback from the previous review and ensures the workflow configuration is minimal and intuitive.