### PR TITLE
fix: Update iOS dialog properties on recomposition without recreating UIAlertController

### DIFF
--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.ios.kt
@@ -96,6 +96,7 @@ actual fun AdaptiveAlertDialog(
         alertDialogManager.iosProperties = createIosDialogProperties()
         alertDialogManager.properties = properties
         alertDialogManager.layoutDirection = layoutDirection
+        alertDialogManager.updateDialogProperties()
     }
 
     DisposableEffect(Unit) {
@@ -134,6 +135,7 @@ actual fun AdaptiveBasicAlertDialog(
         alertDialogManager.iosProperties = iosProperties
         alertDialogManager.properties = properties
         alertDialogManager.layoutDirection = layoutDirection
+        alertDialogManager.updateDialogProperties()
     }
 
     DisposableEffect(Unit) {

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AlertDialogManager.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AlertDialogManager.kt
@@ -91,6 +91,28 @@ class AlertDialogManager internal constructor(
     }
 
     /**
+     * Updates the properties of the already-presented [UIAlertController]
+     * without dismissing and recreating it.
+     *
+     * Updatable properties:
+     * - [UIAlertController.title] and [UIAlertController.message]
+     * - [UIAlertAction.enabled] for each action
+     */
+    internal fun updateDialogProperties() {
+        val controller = dialogUIViewController as? UIAlertController ?: return
+
+        controller.title = iosProperties.title
+        controller.message = iosProperties.text
+
+        val actions = iosProperties.actions
+        for (i in actions.indices) {
+            if (i < controller.actions.size) {
+                (controller.actions[i] as? UIAlertAction)?.enabled = actions[i].enabled
+            }
+        }
+    }
+
+    /**
      * Lambda that dismisses the dialog.
      */
     private val onDismissLambda: (() -> Unit) = {

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/AlertDialogScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/AlertDialogScreen.kt
@@ -26,6 +26,8 @@ fun AlertDialogScreen(
     navigateBack: () -> Unit
 ) {
     var showSimpleDialog by remember { mutableStateOf(false) }
+    var showTextFieldDialog by remember { mutableStateOf(false) }
+    var textFieldValue by remember { mutableStateOf("") }
     var showComplexDialog by remember { mutableStateOf(false) }
     var showActionSheetDialog by remember { mutableStateOf(false) }
 
@@ -61,6 +63,29 @@ fun AlertDialogScreen(
             }
 
             if (currentPlatform.isIOS) {
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "Dialog with Text Field",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Confirm button is disabled until text is entered",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                AdaptiveButton(
+                    onClick = {
+                        textFieldValue = ""
+                        showTextFieldDialog = true
+                    },
+                ) {
+                    Text("Show Text Field Dialog")
+                }
+
                 Spacer(modifier = Modifier.height(24.dp))
 
                 Text(
@@ -104,6 +129,54 @@ fun AlertDialogScreen(
                 dismissText = "Cancel",
                 title = "Alert Dialog",
                 text = "This is a native alert dialog from Calf",
+            )
+        }
+
+        val textFieldDialogIosProperties = rememberAlertDialogIosProperties(
+            title = "Enter Name",
+            text = "Please type a name to enable the confirm button.",
+            style = AlertDialogIosStyle.Alert,
+            actions = listOf(
+                AlertDialogIosAction(
+                    title = "Confirm",
+                    style = AlertDialogIosActionStyle.Default,
+                    enabled = textFieldValue.isNotEmpty(),
+                    onClick = {
+                        showTextFieldDialog = false
+                    },
+                ),
+                AlertDialogIosAction(
+                    title = "Cancel",
+                    style = AlertDialogIosActionStyle.Cancel,
+                    onClick = {
+                        showTextFieldDialog = false
+                    },
+                ),
+            ),
+            textFields = listOf(
+                AlertDialogIosTextField(
+                    placeholder = "Name",
+                    initialValue = "",
+                    onValueChange = { textFieldValue = it },
+                ),
+            ),
+        )
+
+        if (showTextFieldDialog) {
+            AdaptiveBasicAlertDialog(
+                onDismissRequest = {
+                    showTextFieldDialog = false
+                },
+                iosProperties = textFieldDialogIosProperties,
+                materialContent = {
+                    Button(
+                        onClick = {
+                            showTextFieldDialog = false
+                        }
+                    ) {
+                        Text("Confirm")
+                    }
+                },
             )
         }
 


### PR DESCRIPTION
- Store UIAlertAction references in AlertDialogManager to update enabled state
- Add updateDialogProperties() to sync title, message, and action enabled state
- Call updateDialogProperties() from LaunchedEffect in both dialog composables
- Add sample demonstrating text field dialog with dynamic button enable/disable

Fixes #519

https://github.com/user-attachments/assets/b0aac657-4b27-4711-87f8-adb4e8b30700

