### PR TITLE
fix(ui): allow single-button AdaptiveAlertDialog by making dismissText optional

### DIFF
--- a/calf-ui/build.gradle.kts
+++ b/calf-ui/build.gradle.kts
@@ -11,6 +11,15 @@ kotlin {
         implementation(libs.kotlinx.coroutines.core)
     }
 
+    sourceSets.commonTest.dependencies {
+        implementation(libs.kotlin.test)
+    }
+
+    sourceSets.desktopTest.dependencies {
+        implementation(libs.compose.ui.test)
+        implementation(compose.desktop.currentOs)
+    }
+
     sourceSets.androidMain.dependencies {
         implementation(libs.activity.compose)
         implementation(libs.kotlinx.coroutines.android)

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.kt
@@ -28,8 +28,11 @@ import com.mohamedrejeb.calf.ui.dialog.uikit.rememberAlertDialogIosProperties
  * If materialDismissButton is provided, this lambda will not be used for non-iOS platforms.
  * @param confirmText The text of the confirm button.
  * if materialConfirmButton is provided, this text will not be used for non-iOS platforms.
- * @param dismissText The text of the dismiss button.
+ * @param dismissText The text of the dismiss button. Pass null, or a blank string, to show a
+ * single-button dialog with only the confirm button.
  * if materialDismissButton is provided, this text will not be used for non-iOS platforms.
+ * On iOS the set of buttons is fixed when the dialog is first presented, so switching
+ * between null and a value while the dialog is shown only takes effect once it is shown again.
  * @param title The title of the dialog.
  * if materialTitle is provided, this text will not be used for non-iOS platforms.
  * @param text The text of the dialog.
@@ -63,7 +66,7 @@ expect fun AdaptiveAlertDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
     confirmText: String,
-    dismissText: String,
+    dismissText: String? = null,
     title: String,
     text: String,
 

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialogActions.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialogActions.kt
@@ -1,0 +1,44 @@
+package com.mohamedrejeb.calf.ui.dialog
+
+import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosAction
+import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosActionStyle
+
+/**
+ * Resolves the label of the dismiss button shown by [AdaptiveAlertDialog].
+ *
+ * Both null and blank text mean "no dismiss button". A blank label would otherwise
+ * render an empty but tappable button, which is never a valid dialog.
+ */
+internal fun dismissLabelOrNull(dismissText: String?): String? =
+    dismissText?.takeIf { it.isNotBlank() }
+
+/**
+ * Builds the native iOS actions shown by [AdaptiveAlertDialog].
+ *
+ * The confirm action always comes first. The dismiss action is only added when
+ * [dismissText] resolves to a label through [dismissLabelOrNull], which is how a
+ * single-button dialog is expressed.
+ */
+internal fun adaptiveAlertDialogIosActions(
+    confirmText: String,
+    dismissText: String?,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    confirmStyle: AlertDialogIosActionStyle,
+    dismissStyle: AlertDialogIosActionStyle,
+    confirmIsPreferred: Boolean,
+): List<AlertDialogIosAction> = listOfNotNull(
+    AlertDialogIosAction(
+        title = confirmText,
+        style = confirmStyle,
+        onClick = onConfirm,
+        isPreferred = confirmIsPreferred,
+    ),
+    dismissLabelOrNull(dismissText)?.let { label ->
+        AlertDialogIosAction(
+            title = label,
+            style = dismissStyle,
+            onClick = onDismiss,
+        )
+    },
+)

--- a/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialogActionsTest.kt
+++ b/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialogActionsTest.kt
@@ -1,0 +1,82 @@
+package com.mohamedrejeb.calf.ui.dialog
+
+import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosActionStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AdaptiveAlertDialogActionsTest {
+
+    @Test
+    fun `builds only the confirm action when dismissText is null`() {
+        val actions = adaptiveAlertDialogIosActions(
+            confirmText = "OK",
+            dismissText = null,
+            onConfirm = {},
+            onDismiss = {},
+            confirmStyle = AlertDialogIosActionStyle.Default,
+            dismissStyle = AlertDialogIosActionStyle.Cancel,
+            confirmIsPreferred = false,
+        )
+
+        assertEquals(listOf("OK"), actions.map { it.title })
+    }
+
+    @Test
+    fun `builds only the confirm action when dismissText is blank`() {
+        val actions = adaptiveAlertDialogIosActions(
+            confirmText = "OK",
+            dismissText = "   ",
+            onConfirm = {},
+            onDismiss = {},
+            confirmStyle = AlertDialogIosActionStyle.Default,
+            dismissStyle = AlertDialogIosActionStyle.Cancel,
+            confirmIsPreferred = false,
+        )
+
+        assertEquals(listOf("OK"), actions.map { it.title })
+    }
+
+    @Test
+    fun `builds confirm then dismiss action when dismissText is provided`() {
+        val actions = adaptiveAlertDialogIosActions(
+            confirmText = "OK",
+            dismissText = "Cancel",
+            onConfirm = {},
+            onDismiss = {},
+            confirmStyle = AlertDialogIosActionStyle.Default,
+            dismissStyle = AlertDialogIosActionStyle.Destructive,
+            confirmIsPreferred = true,
+        )
+
+        assertEquals(listOf("OK", "Cancel"), actions.map { it.title })
+        assertEquals(
+            listOf(AlertDialogIosActionStyle.Default, AlertDialogIosActionStyle.Destructive),
+            actions.map { it.style },
+        )
+        assertEquals(listOf(true, false), actions.map { it.isPreferred })
+    }
+
+    @Test
+    fun `wires confirm and dismiss callbacks to their own actions`() {
+        var confirmed = false
+        var dismissed = false
+        val actions = adaptiveAlertDialogIosActions(
+            confirmText = "OK",
+            dismissText = "Cancel",
+            onConfirm = { confirmed = true },
+            onDismiss = { dismissed = true },
+            confirmStyle = AlertDialogIosActionStyle.Default,
+            dismissStyle = AlertDialogIosActionStyle.Cancel,
+            confirmIsPreferred = false,
+        )
+
+        actions[0].onClick()
+        assertTrue(confirmed)
+        assertFalse(dismissed)
+
+        actions[1].onClick()
+        assertTrue(dismissed)
+    }
+}

--- a/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialogMaterialTest.kt
+++ b/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialogMaterialTest.kt
@@ -1,0 +1,93 @@
+package com.mohamedrejeb.calf.ui.dialog
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class AdaptiveAlertDialogMaterialTest {
+
+    private val isButton = SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+
+    @Test
+    fun `shows only the confirm button when dismissText is null`() = runComposeUiTest {
+        setContent {
+            AdaptiveAlertDialog(
+                onConfirm = {},
+                onDismiss = {},
+                confirmText = "OK",
+                dismissText = null,
+                title = "Title",
+                text = "Message",
+            )
+        }
+
+        onNodeWithText("OK").assertIsDisplayed()
+        onAllNodes(isButton).assertCountEquals(1)
+    }
+
+    @Test
+    fun `shows only the confirm button when dismissText is blank`() = runComposeUiTest {
+        setContent {
+            AdaptiveAlertDialog(
+                onConfirm = {},
+                onDismiss = {},
+                confirmText = "OK",
+                dismissText = "   ",
+                title = "Title",
+                text = "Message",
+            )
+        }
+
+        onNodeWithText("OK").assertIsDisplayed()
+        onAllNodes(isButton).assertCountEquals(1)
+    }
+
+    @Test
+    fun `renders materialDismissButton even when dismissText is null`() = runComposeUiTest {
+        setContent {
+            AdaptiveAlertDialog(
+                onConfirm = {},
+                onDismiss = {},
+                confirmText = "OK",
+                dismissText = null,
+                title = "Title",
+                text = "Message",
+                materialDismissButton = {
+                    TextButton(onClick = {}) {
+                        Text("Custom")
+                    }
+                },
+            )
+        }
+
+        onNodeWithText("Custom").assertIsDisplayed()
+        onAllNodes(isButton).assertCountEquals(2)
+    }
+
+    @Test
+    fun `shows confirm and dismiss buttons when dismissText is provided`() = runComposeUiTest {
+        setContent {
+            AdaptiveAlertDialog(
+                onConfirm = {},
+                onDismiss = {},
+                confirmText = "OK",
+                dismissText = "Cancel",
+                title = "Title",
+                text = "Message",
+            )
+        }
+
+        onNodeWithText("OK").assertIsDisplayed()
+        onNodeWithText("Cancel").assertIsDisplayed()
+        onAllNodes(isButton).assertCountEquals(2)
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.ios.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.window.DialogProperties
 import com.mohamedrejeb.calf.core.InternalCalfApi
-import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosAction
 import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosActionStyle
 import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosProperties
 import com.mohamedrejeb.calf.ui.dialog.uikit.AlertDialogIosStyle
@@ -23,7 +22,7 @@ actual fun AdaptiveAlertDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
     confirmText: String,
-    dismissText: String,
+    dismissText: String?,
     title: String,
     text: String,
     materialConfirmButton: @Composable (() -> Unit)?,
@@ -52,18 +51,14 @@ actual fun AdaptiveAlertDialog(
             title = title,
             text = text,
             style = iosDialogStyle,
-            actions = listOf(
-                AlertDialogIosAction(
-                    title = confirmText,
-                    style = iosConfirmButtonStyle,
-                    onClick = onConfirm,
-                    isPreferred = iosConfirmButtonIsPreferred,
-                ),
-                AlertDialogIosAction(
-                    title = dismissText,
-                    style = iosDismissButtonStyle,
-                    onClick = onDismiss,
-                )
+            actions = adaptiveAlertDialogIosActions(
+                confirmText = confirmText,
+                dismissText = dismissText,
+                onConfirm = onConfirm,
+                onDismiss = onDismiss,
+                confirmStyle = iosConfirmButtonStyle,
+                dismissStyle = iosDismissButtonStyle,
+                confirmIsPreferred = iosConfirmButtonIsPreferred,
             ),
         )
     }

--- a/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.material.kt
+++ b/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/dialog/AdaptiveAlertDialog.material.kt
@@ -21,7 +21,7 @@ actual fun AdaptiveAlertDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
     confirmText: String,
-    dismissText: String,
+    dismissText: String?,
     title: String,
     text: String,
     materialConfirmButton: @Composable (() -> Unit)?,
@@ -42,6 +42,17 @@ actual fun AdaptiveAlertDialog(
     properties: DialogProperties,
     modifier: Modifier,
 ) {
+    val dismissButton: (@Composable () -> Unit)? = materialDismissButton
+        ?: dismissLabelOrNull(dismissText)?.let { label ->
+            {
+                Button(
+                    onClick = onDismiss,
+                ) {
+                    Text(label)
+                }
+            }
+        }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         confirmButton = materialConfirmButton ?: {
@@ -51,13 +62,7 @@ actual fun AdaptiveAlertDialog(
                 Text(confirmText)
             }
         },
-        dismissButton = materialDismissButton ?: {
-            Button(
-                onClick = onDismiss,
-            ) {
-                Text(dismissText)
-            }
-        },
+        dismissButton = dismissButton,
         icon = materialIcon,
         title = materialTitle ?: {
             Text(title)

--- a/docs/ui/adaptive-alert-dialog.md
+++ b/docs/ui/adaptive-alert-dialog.md
@@ -13,7 +13,7 @@ Both composables use native `UIAlertController` on iOS and Material dialogs on o
 
 ## AdaptiveAlertDialog
 
-The `AdaptiveAlertDialog` composable provides a simple API with predefined confirm and dismiss buttons. It's ideal for common dialog scenarios where you just need to show a message with two action buttons.
+The `AdaptiveAlertDialog` composable provides a simple API with predefined confirm and dismiss buttons. It's ideal for common dialog scenarios where you just need to show a message with one or two action buttons.
 
 ```kotlin
 // State to control dialog visibility
@@ -48,6 +48,24 @@ if (showDialog) {
     )
 }
 ```
+
+### Single-button dialog
+
+`dismissText` is optional. Leave it out, pass `null`, or pass a blank string to show only the confirm button. On iOS this presents a single `UIAlertAction`; on Material platforms the `AlertDialog` is rendered without a dismiss button.
+
+```kotlin
+if (showInfoDialog) {
+    AdaptiveAlertDialog(
+        onConfirm = { showInfoDialog = false },
+        onDismiss = { showInfoDialog = false },
+        confirmText = "OK",
+        title = "Saved",
+        text = "Your changes have been saved.",
+    )
+}
+```
+
+`onDismiss` is still invoked when the user taps outside the dialog or presses back, so it stays required. On iOS the set of buttons is fixed when the dialog is first presented: toggling `dismissText` between `null` and a value while the dialog is visible takes effect the next time it is shown.
 
 ## AdaptiveBasicAlertDialog
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ vanniktech-maven-publish = { module = "com.vanniktech.maven.publish:com.vannikte
 compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "compose" }
 compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "compose" }
 compose-ui-graphics = { group = "org.jetbrains.compose.ui", name = "ui-graphics", version.ref = "compose" }
+compose-ui-test = { group = "org.jetbrains.compose.ui", name = "ui-test", version.ref = "compose" }
 compose-components-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "compose" }
 compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "material3" }
 compose-material-icons-extended = { group = "org.jetbrains.compose.material", name = "material-icons-extended", version.ref = "material-icons-extended" }

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/AlertDialogScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/AlertDialogScreen.kt
@@ -26,6 +26,7 @@ fun AlertDialogScreen(
     navigateBack: () -> Unit
 ) {
     var showSimpleDialog by remember { mutableStateOf(false) }
+    var showSingleButtonDialog by remember { mutableStateOf(false) }
     var showTextFieldDialog by remember { mutableStateOf(false) }
     var textFieldValue by remember { mutableStateOf("") }
     var showComplexDialog by remember { mutableStateOf(false) }
@@ -60,6 +61,26 @@ fun AlertDialogScreen(
                 onClick = { showSimpleDialog = true },
             ) {
                 Text("Show Alert Dialog")
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Single Button Alert Dialog",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Omit dismissText to show only the confirm button",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            AdaptiveButton(
+                onClick = { showSingleButtonDialog = true },
+            ) {
+                Text("Show Single Button Dialog")
             }
 
             if (currentPlatform.isIOS) {
@@ -129,6 +150,20 @@ fun AlertDialogScreen(
                 dismissText = "Cancel",
                 title = "Alert Dialog",
                 text = "This is a native alert dialog from Calf",
+            )
+        }
+
+        if (showSingleButtonDialog) {
+            AdaptiveAlertDialog(
+                onConfirm = {
+                    showSingleButtonDialog = false
+                },
+                onDismiss = {
+                    showSingleButtonDialog = false
+                },
+                confirmText = "Got it",
+                title = "Single Button",
+                text = "This dialog only has a confirm button.",
             )
         }
 


### PR DESCRIPTION
Closes #536.

AdaptiveAlertDialog always rendered two buttons, so on iOS an empty dismissText produced a blank UIAlertAction and on Material an empty button. dismissText is now `String? = null`; null or blank text drops the dismiss action/button on every platform.

- Extract the iOS action list into adaptiveAlertDialogIosActions (commonMain, internal) so the logic is unit-tested without a simulator
- Add dismissLabelOrNull shared by the iOS and Material actuals
- Add calf-ui commonTest and desktopTest (Compose ui-test on desktop)
- Sample: "Single Button Alert Dialog" section in AlertDialogScreen
- Docs: single-button section in docs/ui/adaptive-alert-dialog.md
