### PR TITLE
fix(file-picker): reuse identical cached native library instead of replacing it

### DIFF
--- a/calf-file-picker/src/desktopMain/kotlin/com/mohamedrejeb/calf/picker/platform/NativeLibCache.kt
+++ b/calf-file-picker/src/desktopMain/kotlin/com/mohamedrejeb/calf/picker/platform/NativeLibCache.kt
@@ -1,0 +1,71 @@
+package com.mohamedrejeb.calf.picker.platform
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+
+private const val HASH_ALGORITHM = "SHA-256"
+private const val HASH_LENGTH = 16
+private const val TEMP_PREFIX = "calf-native-"
+private const val TEMP_SUFFIX = ".tmp"
+
+/**
+ * Short, stable fingerprint of a native library's bytes.
+ *
+ * Used to name the cached copy so that different builds of the library
+ * never share a file on disk.
+ */
+internal fun nativeLibraryContentHash(bytes: ByteArray): String =
+    MessageDigest.getInstance(HASH_ALGORITHM)
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+        .take(HASH_LENGTH)
+
+/**
+ * Inserts [contentHash] before the extension of [libFileName],
+ * e.g. `calf_filepicker_native.dll` -> `calf_filepicker_native-<hash>.dll`.
+ */
+internal fun nativeLibraryCacheFileName(libFileName: String, contentHash: String): String {
+    val extension = libFileName.substringAfterLast('.', missingDelimiterValue = "")
+    val baseName = libFileName.substringBeforeLast('.')
+    return if (extension.isEmpty()) "$baseName-$contentHash" else "$baseName-$contentHash.$extension"
+}
+
+/**
+ * Makes [bytes] available as a file inside [cacheDir] and returns the file to load.
+ *
+ * - An existing target with identical content is reused untouched, so a library
+ *   that another process has already loaded (and locked, on Windows) is never
+ *   replaced.
+ * - Otherwise the bytes are written to a temp file and moved over the target.
+ * - If the move fails for any reason, the unique temp file itself is returned
+ *   and scheduled for deletion on exit, so loading still succeeds.
+ */
+internal fun extractNativeLibrary(bytes: ByteArray, cacheDir: File, fileName: String): File {
+    cacheDir.mkdirs()
+    val target = File(cacheDir, fileName)
+    if (hasIdenticalContent(target, bytes)) return target
+
+    val tempFile = Files.createTempFile(cacheDir.toPath(), TEMP_PREFIX, TEMP_SUFFIX)
+    Files.write(tempFile, bytes)
+
+    return runCatching { moveReplacing(tempFile, target.toPath()) }
+        .map { target }
+        .getOrElse { tempFile.toFile().also { it.deleteOnExit() } }
+}
+
+private fun hasIdenticalContent(file: File, bytes: ByteArray): Boolean =
+    file.isFile &&
+        file.length() == bytes.size.toLong() &&
+        nativeLibraryContentHash(file.readBytes()) == nativeLibraryContentHash(bytes)
+
+private fun moveReplacing(source: Path, target: Path) {
+    try {
+        Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    } catch (_: Exception) {
+        // ATOMIC_MOVE is not supported on every filesystem; retry with a plain replace.
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+    }
+}

--- a/calf-file-picker/src/desktopMain/kotlin/com/mohamedrejeb/calf/picker/platform/NativeLibLoader.kt
+++ b/calf-file-picker/src/desktopMain/kotlin/com/mohamedrejeb/calf/picker/platform/NativeLibLoader.kt
@@ -1,84 +1,70 @@
 package com.mohamedrejeb.calf.picker.platform
 
 import java.io.File
-import java.io.InputStream
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 
 private const val LIB_NAME = "calf_filepicker_native"
+private const val CACHE_DIR = ".cache/calf-filepicker"
 
 /**
- * Loads the native file picker library from JAR resources.
+ * Loads the native file picker library.
  *
- * The library is expected at: native/<os>-<arch>/<libFileName>
- * It is extracted to a user-scoped cache directory and loaded via [System.load].
+ * The system library path is tried first (packagers like Conveyor extract natives
+ * out of the jar). Otherwise the library is read from JAR resources at
+ * `native/<os>-<arch>/<libFileName>`, cached under a content-hashed name in a
+ * user-scoped directory, and loaded via [System.load].
  *
- * Called once from [NativeFilePickerBridge]'s object init block
+ * Called once from [NativeFilePickerBridge]'s object init block.
  */
 internal fun loadNativeLibrary() {
-    // Try the system path first (packagers like Conveyor extract natives
-    // out of the jar), then fall back to the bundled resource.
     try {
         System.loadLibrary(LIB_NAME)
         return
     } catch (_: UnsatisfiedLinkError) {
     }
 
+    val (resourcePath, libFileName) = bundledLibraryLocation()
+    val bytes = NativeFilePickerBridge::class.java.classLoader
+        ?.getResourceAsStream(resourcePath)
+        ?.use { it.readBytes() }
+        ?: error(
+            "Native library not found in JAR resources at '$resourcePath'. " +
+                "Ensure the native library is built for this platform."
+        )
+
+    val cacheFileName = nativeLibraryCacheFileName(libFileName, nativeLibraryContentHash(bytes))
+    val libraryFile = try {
+        extractNativeLibrary(bytes, userCacheDir(), cacheFileName)
+    } catch (e: Exception) {
+        error("Failed to extract native file picker library '$cacheFileName': ${e.message}")
+    }
+
+    @Suppress("UnsafeDynamicallyLoadedCode")
+    System.load(libraryFile.absolutePath)
+}
+
+/** Resource path inside the JAR and the platform file name of the bundled library. */
+private fun bundledLibraryLocation(): Pair<String, String> {
     val osName = System.getProperty("os.name")?.lowercase().orEmpty()
     val osArch = System.getProperty("os.arch")?.lowercase().orEmpty()
 
     val (osPart, libFileName) = when {
-        "mac" in osName || "darwin" in osName ->
-            "macos" to "lib$LIB_NAME.dylib"
-
-        "win" in osName ->
-            "windows" to "$LIB_NAME.dll"
-
-        "nux" in osName || "nix" in osName ->
-            "linux" to "lib$LIB_NAME.so"
-
+        "mac" in osName || "darwin" in osName -> "macos" to "lib$LIB_NAME.dylib"
+        "win" in osName -> "windows" to "$LIB_NAME.dll"
+        "nux" in osName || "nix" in osName -> "linux" to "lib$LIB_NAME.so"
         else -> error("Unsupported OS: $osName")
     }
 
-    val archPart = when {
-        osArch == "aarch64" || osArch == "arm64" -> "arm64"
-        osArch == "amd64" || osArch == "x86_64" -> "x64"
+    val archPart = when (osArch) {
+        "aarch64", "arm64" -> "arm64"
+        "amd64", "x86_64" -> "x64"
         else -> error("Unsupported architecture: $osArch")
     }
 
-    val resourcePath = "native/$osPart-$archPart/$libFileName"
+    return "native/$osPart-$archPart/$libFileName" to libFileName
+}
 
-    val inputStream: InputStream = NativeFilePickerBridge::class.java.classLoader
-        ?.getResourceAsStream(resourcePath)
-        ?: error(
-            "Native library not found in JAR resources at '$resourcePath'. " +
-                "Ensure the native library is built for $osPart-$archPart."
-        )
-
-    // Use a user-scoped cache directory to avoid shared /tmp security risks
+/** User-scoped cache directory, avoiding the security risks of a shared /tmp. */
+private fun userCacheDir(): File {
     val userHome = System.getProperty("user.home") ?: System.getProperty("java.io.tmpdir")
-    val cacheDir = File(userHome, ".cache/calf-filepicker")
-    cacheDir.mkdirs()
-
-    val targetFile = File(cacheDir, libFileName)
-
-    inputStream.use { input ->
-        val bytes = input.readBytes()
-        val tempFile = Files.createTempFile(cacheDir.toPath(), "calf-native-", ".tmp")
-        try {
-            Files.write(tempFile, bytes)
-            try {
-                Files.move(tempFile, targetFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-            } catch (_: Exception) {
-                // ATOMIC_MOVE not supported on this filesystem, fallback to regular move
-                Files.move(tempFile, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
-            }
-        } catch (e: Exception) {
-            Files.deleteIfExists(tempFile)
-            error("Failed to extract native file picker library to '$targetFile': ${e.message}")
-        }
-    }
-
-    @Suppress("UnsafeDynamicallyLoadedCode")
-    System.load(targetFile.absolutePath)
+    return File(userHome, CACHE_DIR)
 }

--- a/calf-file-picker/src/desktopTest/kotlin/com/mohamedrejeb/calf/picker/platform/NativeLibCacheTest.kt
+++ b/calf-file-picker/src/desktopTest/kotlin/com/mohamedrejeb/calf/picker/platform/NativeLibCacheTest.kt
@@ -1,0 +1,103 @@
+package com.mohamedrejeb.calf.picker.platform
+
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class NativeLibCacheTest {
+
+    private lateinit var cacheDir: File
+
+    @BeforeTest
+    fun setUp() {
+        cacheDir = createTempDirectory("calf-native-cache-test").toFile()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `cache file name inserts the hash before the extension`() {
+        assertEquals(
+            "calf_filepicker_native-0123456789abcdef.dll",
+            nativeLibraryCacheFileName("calf_filepicker_native.dll", "0123456789abcdef"),
+        )
+        assertEquals(
+            "libcalf_filepicker_native-0123456789abcdef.dylib",
+            nativeLibraryCacheFileName("libcalf_filepicker_native.dylib", "0123456789abcdef"),
+        )
+        assertEquals(
+            "libcalf_filepicker_native-0123456789abcdef.so",
+            nativeLibraryCacheFileName("libcalf_filepicker_native.so", "0123456789abcdef"),
+        )
+    }
+
+    @Test
+    fun `content hash is deterministic, differs per content and is 16 hex chars`() {
+        val first = nativeLibraryContentHash(byteArrayOf(1, 2, 3))
+        val same = nativeLibraryContentHash(byteArrayOf(1, 2, 3))
+        val other = nativeLibraryContentHash(byteArrayOf(1, 2, 4))
+
+        assertEquals(first, same)
+        assertNotEquals(first, other)
+        assertTrue(Regex("[0-9a-f]{16}").matches(first), "unexpected hash format: $first")
+    }
+
+    @Test
+    fun `extract writes the file with the exact bytes when it is missing`() {
+        val bytes = byteArrayOf(10, 20, 30, 40)
+
+        val loaded = extractNativeLibrary(bytes, cacheDir, "lib-aaaa.so")
+
+        assertEquals(File(cacheDir, "lib-aaaa.so"), loaded)
+        assertContentEquals(bytes, loaded.readBytes())
+    }
+
+    @Test
+    fun `extract reuses an existing identical file without rewriting it`() {
+        val bytes = byteArrayOf(7, 8, 9)
+        val target = File(cacheDir, "lib-bbbb.so").apply { writeBytes(bytes) }
+        val pastMillis = 1_000_000_000_000L
+        assertTrue(target.setLastModified(pastMillis))
+
+        val loaded = extractNativeLibrary(bytes, cacheDir, "lib-bbbb.so")
+
+        assertEquals(target, loaded)
+        assertEquals(pastMillis, loaded.lastModified())
+        assertContentEquals(bytes, loaded.readBytes())
+    }
+
+    @Test
+    fun `extract replaces an existing file whose bytes differ`() {
+        val target = File(cacheDir, "lib-cccc.so").apply { writeBytes(byteArrayOf(1, 1, 1)) }
+        val bytes = byteArrayOf(2, 2, 2, 2)
+
+        val loaded = extractNativeLibrary(bytes, cacheDir, "lib-cccc.so")
+
+        assertEquals(target, loaded)
+        assertContentEquals(bytes, loaded.readBytes())
+    }
+
+    @Test
+    fun `extract falls back to a unique file in the cache dir when the target cannot be replaced`() {
+        val blockedTarget = File(cacheDir, "lib-dddd.so")
+        assertTrue(blockedTarget.mkdir())
+        assertTrue(File(blockedTarget, "occupied").createNewFile())
+        val bytes = byteArrayOf(5, 5, 5)
+
+        val loaded = extractNativeLibrary(bytes, cacheDir, "lib-dddd.so")
+
+        assertNotEquals(blockedTarget, loaded)
+        assertEquals(cacheDir, loaded.parentFile)
+        assertTrue(loaded.isFile)
+        assertContentEquals(bytes, loaded.readBytes())
+    }
+}

--- a/docs/filepicker.md
+++ b/docs/filepicker.md
@@ -156,6 +156,12 @@ Passing `null` (the default) allows unlimited selection. `FilePickerSelectionMod
 
 ## Desktop Setup
 
+#### Native library cache
+
+The desktop file picker relies on a small native library bundled inside the JAR. On first use it is extracted to `~/.cache/calf-filepicker/`. The cached file name includes a hash of the library's content, so several applications, product flavors, or Calf versions running on the same machine never overwrite each other's copy, and an identical library that is already present is reused as is.
+
+Packagers that place the library on the system library path (for example Conveyor) skip the extraction entirely, since the loader tries `System.loadLibrary` first.
+
 #### macOS Dark Theme
 
 The file dialog follows the application's theme. To enable dark mode support on macOS, add this JVM argument to your Gradle configuration:


### PR DESCRIPTION
Closes #534.

Two apps bundling the same picker extracted the native library to one fixed path, and on Windows the second app failed because the first had the DLL loaded and locked. The cached copy is now named with a content hash, an existing identical file is reused untouched, and if the target still cannot be replaced the loader falls back to a unique temp file instead of failing.