### PR TITLE
feat(ui): add a cross-platform selectable dates rule to AdaptiveDatePicker

### DIFF
--- a/calf-ui/build.gradle.kts
+++ b/calf-ui/build.gradle.kts
@@ -11,6 +11,15 @@ kotlin {
         implementation(libs.kotlinx.coroutines.core)
     }
 
+    sourceSets.commonTest.dependencies {
+        implementation(libs.kotlin.test)
+    }
+
+    sourceSets.desktopTest.dependencies {
+        implementation(libs.compose.ui.test)
+        implementation(compose.desktop.currentOs)
+    }
+
     sourceSets.androidMain.dependencies {
         implementation(libs.activity.compose)
         implementation(libs.kotlinx.coroutines.android)

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerState.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerState.kt
@@ -5,6 +5,23 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 
+/**
+ * Creates and remembers an [AdaptiveDatePickerState].
+ *
+ * @param initialSelectedDateMillis timestamp in _UTC_ milliseconds from the epoch that
+ * represents an initial selection of a date. Provide a `null` to indicate no selection.
+ * @param initialDisplayedMonthMillis timestamp in _UTC_ milliseconds from the epoch that
+ * represents an initial selection of a month to be displayed to the user. In case `null` is
+ * provided, the displayed month would be the current one.
+ * @param yearRange an [IntRange] that holds the year range that the date picker will be limited
+ * to
+ * @param initialMaterialDisplayMode an initial [DisplayMode] that this state will hold
+ * @param initialUIKitDisplayMode an initial [UIKitDisplayMode] used by the iOS picker
+ * @param selectableDates the rule deciding which days can be picked, see
+ * [AdaptiveDatePickerState.selectableDates]. Use [DateBounds] for a minimum and maximum day and
+ * [and] to combine rules. Pass a stable instance (for example an `object`, a `data class` or a
+ * remembered value) so the picker does not re-evaluate on every recomposition.
+ */
 @Composable
 @ExperimentalMaterial3Api
 fun rememberAdaptiveDatePickerState(
@@ -13,9 +30,10 @@ fun rememberAdaptiveDatePickerState(
     yearRange: IntRange = DatePickerDefaults.YearRange,
     initialMaterialDisplayMode: DisplayMode = DisplayMode.Picker,
     initialUIKitDisplayMode: UIKitDisplayMode = UIKitDisplayMode.Picker,
+    selectableDates: SelectableDates = DatePickerDefaults.AllDates,
 ): AdaptiveDatePickerState =
     rememberSaveable(
-        saver = AdaptiveDatePickerState.Saver(),
+        saver = AdaptiveDatePickerState.Saver(selectableDates),
     ) {
         AdaptiveDatePickerState(
             initialSelectedDateMillis = initialSelectedDateMillis,
@@ -23,7 +41,11 @@ fun rememberAdaptiveDatePickerState(
             yearRange = yearRange,
             initialMaterialDisplayMode = initialMaterialDisplayMode,
             initialUIKitDisplayMode = initialUIKitDisplayMode,
+            selectableDates = selectableDates,
         )
+    }.apply {
+        // Keep the rule in sync when the caller passes a new one on recomposition.
+        this.selectableDates = selectableDates
     }
 
 /**
@@ -43,6 +65,8 @@ fun rememberAdaptiveDatePickerState(
  * @param yearRange an [IntRange] that holds the year range that the date picker will be limited
  * to
  * @param initialMaterialDisplayMode an initial [DisplayMode] that this state will hold
+ * @param initialUIKitDisplayMode an initial [UIKitDisplayMode] used by the iOS picker
+ * @param selectableDates initial value of [AdaptiveDatePickerState.selectableDates]
  * @see rememberAdaptiveDatePickerState
  * @throws [IllegalArgumentException] if the initial selected date or displayed month represent
  * a year that is out of the year range.
@@ -55,6 +79,7 @@ expect class AdaptiveDatePickerState(
     yearRange: IntRange,
     initialMaterialDisplayMode: DisplayMode,
     initialUIKitDisplayMode: UIKitDisplayMode,
+    selectableDates: SelectableDates = DatePickerDefaults.AllDates,
 ) {
     /**
      * A timestamp that represents the _start_ of the day of the selected date in _UTC_ milliseconds
@@ -87,11 +112,26 @@ expect class AdaptiveDatePickerState(
      */
     var displayMode: DisplayMode
 
+    /**
+     * The [SelectableDates] rule deciding which days can be picked. Use [DateBounds] for a
+     * minimum and maximum day, and [and] to combine rules.
+     *
+     * Honoured by the Material picker and by the iOS 16+ calendars, where rejected days are
+     * greyed out; bounds coming from a [DateBounds] are also applied natively, so the iOS wheels
+     * stop at the range. The iOS wheels picker, and the inline picker below iOS 16, cannot grey
+     * out days: a rejected day is snapped to the nearest selectable one instead. Observable:
+     * changing it updates the displayed picker, and a selection the new rule rejects is moved
+     * to the nearest selectable day. [SelectableDates.isSelectableYear] only affects Material.
+     */
+    var selectableDates: SelectableDates
+
     companion object {
         /**
          * The default [Saver] implementation for [AdaptiveDatePickerState].
+         *
+         * @param selectableDates the rule to re-attach on restore, since it cannot be saved.
          */
-        fun Saver(): Saver<AdaptiveDatePickerState, *>
+        fun Saver(selectableDates: SelectableDates = DatePickerDefaults.AllDates): Saver<AdaptiveDatePickerState, Any>
     }
 }
 

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateBounds.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateBounds.kt
@@ -1,0 +1,76 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+import androidx.compose.runtime.Immutable
+
+/**
+ * A [SelectableDates] rule that accepts the days from [minDateMillis] to [maxDateMillis], both
+ * inclusive and compared per UTC day, so any timestamp inside the first or last day keeps that
+ * whole day selectable. A `null` bound is open on that side.
+ *
+ * Besides greying out days, the pickers apply these bounds natively: the iOS wheels stop at the
+ * range and the calendars hide the months outside it. Combine with other rules using [and].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Immutable
+data class DateBounds(
+    val minDateMillis: Long? = null,
+    val maxDateMillis: Long? = null,
+) : SelectableDates {
+    override fun isSelectableDate(utcTimeMillis: Long): Boolean =
+        isDayWithinBounds(utcTimeMillis, minDateMillis, maxDateMillis)
+
+    override fun isSelectableYear(year: Int): Boolean =
+        isYearWithinBounds(year, minDateMillis, maxDateMillis)
+}
+
+/** A rule that accepts a day, or a year, only when both this rule and [other] accept it. */
+@OptIn(ExperimentalMaterial3Api::class)
+infix fun SelectableDates.and(other: SelectableDates): SelectableDates =
+    CombinedSelectableDates(this, other)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Immutable
+internal data class CombinedSelectableDates(
+    val first: SelectableDates,
+    val second: SelectableDates,
+) : SelectableDates {
+    override fun isSelectableDate(utcTimeMillis: Long): Boolean =
+        first.isSelectableDate(utcTimeMillis) && second.isSelectableDate(utcTimeMillis)
+
+    override fun isSelectableYear(year: Int): Boolean =
+        first.isSelectableYear(year) && second.isSelectableYear(year)
+}
+
+/**
+ * The bounds this rule enforces when it is a [DateBounds], or combines one through [and];
+ * `null` for any other rule.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun SelectableDates.dateBoundsOrNull(): DateBounds? =
+    when (this) {
+        is DateBounds -> this
+        is CombinedSelectableDates -> intersectOrNull(first.dateBoundsOrNull(), second.dateBoundsOrNull())
+        else -> null
+    }
+
+/** The days accepted by both this and [other]. */
+internal fun DateBounds.intersect(other: DateBounds): DateBounds =
+    DateBounds(
+        minDateMillis = tighterMin(minDateMillis, other.minDateMillis),
+        maxDateMillis = tighterMax(maxDateMillis, other.maxDateMillis),
+    )
+
+private fun intersectOrNull(first: DateBounds?, second: DateBounds?): DateBounds? =
+    when {
+        first == null -> second
+        second == null -> first
+        else -> first.intersect(second)
+    }
+
+private fun tighterMin(first: Long?, second: Long?): Long? =
+    if (first == null || second == null) first ?: second else maxOf(first, second)
+
+private fun tighterMax(first: Long?, second: Long?): Long? =
+    if (first == null || second == null) first ?: second else minOf(first, second)

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/RuleTrackingDatePickerState.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/RuleTrackingDatePickerState.kt
@@ -1,0 +1,22 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+
+/**
+ * A [DatePickerState] that reports the rule returned by [currentRule] instead of the one it was
+ * created with.
+ *
+ * Material3 caches each day's enabled state keyed on the rule object, so the picker only
+ * notices a change when the object itself changes. Handing it the caller's rule, which is a
+ * new object whenever the rule changes, keeps the calendar in sync.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+internal class RuleTrackingDatePickerState(
+    delegate: DatePickerState,
+    private val currentRule: () -> SelectableDates,
+) : DatePickerState by delegate {
+    override val selectableDates: SelectableDates
+        get() = currentRule()
+}

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/SelectableDays.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/SelectableDays.kt
@@ -1,0 +1,161 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+
+internal const val MILLIS_PER_DAY = 86_400_000L
+
+/** How far, in days on each side, a snapped selection may move to find a selectable day. */
+internal const val DEFAULT_SNAP_SEARCH_DAYS = 366
+
+private const val DAYS_FROM_CIVIL_EPOCH_TO_UNIX_EPOCH = 719_468L
+private const val DAYS_PER_ERA = 146_097L
+private const val YEARS_PER_ERA = 400L
+
+/**
+ * Returns true when the UTC day containing [utcTimeMillis] lies within the inclusive
+ * [minDateMillis]..[maxDateMillis] range.
+ *
+ * Bounds are compared at day granularity, so any timestamp inside the min or max day keeps
+ * that whole day selectable. A null bound is open on that side.
+ */
+internal fun isDayWithinBounds(
+    utcTimeMillis: Long,
+    minDateMillis: Long?,
+    maxDateMillis: Long?,
+): Boolean {
+    val day = utcTimeMillis.floorDiv(MILLIS_PER_DAY)
+    val afterMin = minDateMillis == null || day >= minDateMillis.floorDiv(MILLIS_PER_DAY)
+    val beforeMax = maxDateMillis == null || day <= maxDateMillis.floorDiv(MILLIS_PER_DAY)
+    return afterMin && beforeMax
+}
+
+/**
+ * Returns true when [year] contains at least one day of the inclusive
+ * [minDateMillis]..[maxDateMillis] range. A null bound is open on that side.
+ */
+internal fun isYearWithinBounds(
+    year: Int,
+    minDateMillis: Long?,
+    maxDateMillis: Long?,
+): Boolean {
+    val afterMin = minDateMillis == null || year >= utcYearOf(minDateMillis)
+    val beforeMax = maxDateMillis == null || year <= utcYearOf(maxDateMillis)
+    return afterMin && beforeMax
+}
+
+/**
+ * Moves the UTC day containing [utcTimeMillis] into the inclusive bounds.
+ *
+ * Returns [utcTimeMillis] unchanged when it is already inside, otherwise the _start_ of the
+ * minimum or maximum day in UTC, whichever is nearer. A null bound is open on that side.
+ */
+internal fun clampDayIntoBounds(
+    utcTimeMillis: Long,
+    minDateMillis: Long?,
+    maxDateMillis: Long?,
+): Long {
+    val day = utcTimeMillis.floorDiv(MILLIS_PER_DAY)
+    val minDay = minDateMillis?.floorDiv(MILLIS_PER_DAY)
+    val maxDay = maxDateMillis?.floorDiv(MILLIS_PER_DAY)
+    return when {
+        minDay != null && day < minDay -> minDay * MILLIS_PER_DAY
+        maxDay != null && day > maxDay -> maxDay * MILLIS_PER_DAY
+        else -> utcTimeMillis
+    }
+}
+
+/**
+ * Proleptic Gregorian year of a UTC timestamp, computed without a calendar dependency
+ * using the days-to-civil algorithm from Howard Hinnant's date algorithms.
+ */
+internal fun utcYearOf(utcTimeMillis: Long): Int {
+    val days = utcTimeMillis.floorDiv(MILLIS_PER_DAY)
+    val shifted = days + DAYS_FROM_CIVIL_EPOCH_TO_UNIX_EPOCH
+    val era = shifted.floorDiv(DAYS_PER_ERA)
+    val dayOfEra = shifted - era * DAYS_PER_ERA
+    val yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36524 - dayOfEra / 146096) / 365
+    val dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
+    val monthIndex = (5 * dayOfYear + 2) / 153 // 0 is March, 11 is February
+    val marchBasedYear = yearOfEra + era * YEARS_PER_ERA
+    return (if (monthIndex >= 10) marchBasedYear + 1 else marchBasedYear).toInt()
+}
+
+/**
+ * Finds the selectable day nearest to [utcTimeMillis] and returns its _start_ in UTC.
+ *
+ * The day is first clamped into the bounds, then the search walks outwards one day at a
+ * time, later days first, until [selectableDates] accepts one. Returns null when no day within
+ * [maxDistanceDays] on either side is selectable.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun nearestSelectableDay(
+    utcTimeMillis: Long,
+    minDateMillis: Long?,
+    maxDateMillis: Long?,
+    selectableDates: SelectableDates,
+    maxDistanceDays: Int = DEFAULT_SNAP_SEARCH_DAYS,
+): Long? {
+    fun isSelectable(day: Long): Boolean {
+        val dayStart = day * MILLIS_PER_DAY
+        return isDayWithinBounds(dayStart, minDateMillis, maxDateMillis) &&
+            selectableDates.isSelectableDate(dayStart)
+    }
+
+    val startDay = clampDayIntoBounds(utcTimeMillis, minDateMillis, maxDateMillis)
+        .floorDiv(MILLIS_PER_DAY)
+    if (isSelectable(startDay)) return startDay * MILLIS_PER_DAY
+
+    for (distance in 1..maxDistanceDays) {
+        val later = startDay + distance
+        if (isSelectable(later)) return later * MILLIS_PER_DAY
+        val earlier = startDay - distance
+        if (isSelectable(earlier)) return earlier * MILLIS_PER_DAY
+    }
+    return null
+}
+
+/**
+ * The day a native picker should end up on after the user picked [pickedUtcTimeMillis]: the
+ * pick itself when [bounds] and [selectableDates] accept it, otherwise the nearest selectable
+ * day, or the pick unchanged when none is within reach.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun resolvePickedDay(
+    pickedUtcTimeMillis: Long,
+    bounds: DateBounds,
+    selectableDates: SelectableDates,
+): Long {
+    val accepted = isDayWithinBounds(pickedUtcTimeMillis, bounds.minDateMillis, bounds.maxDateMillis) &&
+        selectableDates.isSelectableDate(pickedUtcTimeMillis)
+    if (accepted) return pickedUtcTimeMillis
+    return nearestSelectableDay(pickedUtcTimeMillis, bounds.minDateMillis, bounds.maxDateMillis, selectableDates)
+        ?: pickedUtcTimeMillis
+}
+
+/** True when the rule accepts the day containing [utcTimeMillis]. */
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun AdaptiveDatePickerState.isDaySelectable(utcTimeMillis: Long): Boolean =
+    selectableDates.isSelectableDate(utcTimeMillis)
+
+/** The bounds the rule enforces natively; open on both sides for rules without bounds. */
+@OptIn(ExperimentalMaterial3Api::class)
+internal val AdaptiveDatePickerState.dateBounds: DateBounds
+    get() = selectableDates.dateBoundsOrNull() ?: DateBounds()
+
+/**
+ * Moves an existing selection to the nearest selectable day when the rule no longer accepts
+ * it, so every platform behaves the same way. The selection is left untouched when no
+ * selectable day exists within [DEFAULT_SNAP_SEARCH_DAYS].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun AdaptiveDatePickerState.snapSelectionToSelectable() {
+    val selected = selectedDateMillis ?: return
+    if (isDaySelectable(selected)) return
+    val bounds = dateBounds
+    val snapped = nearestSelectableDay(selected, bounds.minDateMillis, bounds.maxDateMillis, selectableDates)
+        ?: return
+    if (snapped != selected) {
+        selectedDateMillis = snapped
+    }
+}

--- a/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateBoundsSelectableDatesTest.kt
+++ b/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateBoundsSelectableDatesTest.kt
@@ -1,0 +1,70 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalMaterial3Api::class)
+class DateBoundsSelectableDatesTest {
+
+    @Test
+    fun `date bounds accept the days inside and reject the days outside`() {
+        val march = DateBounds(minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026)
+
+        assertFalse(march.isSelectableDate(FEB_28_2026))
+        assertTrue(march.isSelectableDate(MAR_1_2026))
+        assertTrue(march.isSelectableDate(MAR_31_2026 + NOON_OFFSET_MILLIS))
+        assertFalse(march.isSelectableDate(APR_1_2026))
+    }
+
+    @Test
+    fun `date bounds with one side open accept everything on that side`() {
+        assertTrue(DateBounds(minDateMillis = MAR_1_2026).isSelectableDate(APR_1_2026))
+        assertTrue(DateBounds(maxDateMillis = MAR_31_2026).isSelectableDate(FEB_28_2026))
+        assertTrue(DateBounds().isSelectableDate(FEB_29_2000))
+    }
+
+    @Test
+    fun `date bounds reject the years outside`() {
+        val march = DateBounds(minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026)
+
+        assertFalse(march.isSelectableYear(2025))
+        assertTrue(march.isSelectableYear(2026))
+        assertFalse(march.isSelectableYear(2027))
+    }
+
+    @Test
+    fun `and accepts a day only when both rules accept it`() {
+        val marchWeekdays = DateBounds(minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026) and WeekdaysOnly
+
+        assertTrue(marchWeekdays.isSelectableDate(MAR_13_2026))
+        assertFalse(marchWeekdays.isSelectableDate(MAR_14_2026))
+        assertFalse(marchWeekdays.isSelectableDate(APR_1_2026))
+        assertFalse(marchWeekdays.isSelectableYear(2025))
+    }
+
+    @Test
+    fun `bounds are extracted from date bounds and intersected through and`() {
+        val march = DateBounds(minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026)
+        val fromMid = DateBounds(minDateMillis = MAR_15_2026)
+
+        assertEquals(march, march.dateBoundsOrNull())
+        assertEquals(
+            DateBounds(minDateMillis = MAR_15_2026, maxDateMillis = MAR_31_2026),
+            (march and fromMid).dateBoundsOrNull(),
+        )
+        assertEquals(march, (march and WeekdaysOnly).dateBoundsOrNull())
+        assertEquals(march, (WeekdaysOnly and march).dateBoundsOrNull())
+    }
+
+    @Test
+    fun `other rules expose no bounds`() {
+        assertNull(WeekdaysOnly.dateBoundsOrNull())
+        assertNull(DatePickerDefaults.AllDates.dateBoundsOrNull())
+        assertNull((WeekdaysOnly and NoDates).dateBoundsOrNull())
+    }
+}

--- a/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateBoundsTest.kt
+++ b/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateBoundsTest.kt
@@ -1,0 +1,110 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalMaterial3Api::class)
+class DateBoundsTest {
+
+    @Test
+    fun `every day is within bounds when no bounds are set`() {
+        assertTrue(isDayWithinBounds(MAR_15_2026 + NOON_OFFSET_MILLIS, minDateMillis = null, maxDateMillis = null))
+    }
+
+    @Test
+    fun `days before the minimum are rejected and the minimum day itself is accepted`() {
+        assertFalse(isDayWithinBounds(FEB_28_2026, minDateMillis = MAR_1_2026, maxDateMillis = null))
+        assertTrue(isDayWithinBounds(MAR_1_2026, minDateMillis = MAR_1_2026, maxDateMillis = null))
+    }
+
+    @Test
+    fun `days after the maximum are rejected and the maximum day itself is accepted`() {
+        assertTrue(isDayWithinBounds(MAR_31_2026, minDateMillis = null, maxDateMillis = MAR_31_2026))
+        assertFalse(isDayWithinBounds(APR_1_2026, minDateMillis = null, maxDateMillis = MAR_31_2026))
+    }
+
+    @Test
+    fun `bounds are compared at day granularity`() {
+        assertTrue(isDayWithinBounds(MAR_1_2026, minDateMillis = MAR_1_2026 + NOON_OFFSET_MILLIS, maxDateMillis = null))
+        assertTrue(isDayWithinBounds(MAR_31_2026 + NOON_OFFSET_MILLIS, minDateMillis = null, maxDateMillis = MAR_31_2026))
+    }
+
+    @Test
+    fun `years outside the bounds are rejected`() {
+        assertFalse(isYearWithinBounds(2025, minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026))
+        assertTrue(isYearWithinBounds(2026, minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026))
+        assertFalse(isYearWithinBounds(2027, minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026))
+        assertTrue(isYearWithinBounds(1999, minDateMillis = null, maxDateMillis = null))
+    }
+
+    @Test
+    fun `utc year is derived from epoch millis across year and leap boundaries`() {
+        assertEquals(1970, utcYearOf(0))
+        assertEquals(1969, utcYearOf(-1))
+        assertEquals(2000, utcYearOf(FEB_29_2000))
+        assertEquals(2024, utcYearOf(JAN_1_2025 - 1))
+        assertEquals(2025, utcYearOf(JAN_1_2025))
+        assertEquals(2026, utcYearOf(MAR_1_2026))
+    }
+
+    @Test
+    fun `clamping keeps a day inside the bounds unchanged`() {
+        assertEquals(MAR_15_2026, clampDayIntoBounds(MAR_15_2026, minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026))
+    }
+
+    @Test
+    fun `clamping moves a day before the minimum to the start of the minimum day`() {
+        assertEquals(MAR_1_2026, clampDayIntoBounds(FEB_28_2026, minDateMillis = MAR_1_2026 + NOON_OFFSET_MILLIS, maxDateMillis = null))
+    }
+
+    @Test
+    fun `clamping moves a day after the maximum to the start of the maximum day`() {
+        assertEquals(MAR_31_2026, clampDayIntoBounds(APR_1_2026, minDateMillis = null, maxDateMillis = MAR_31_2026 + NOON_OFFSET_MILLIS))
+    }
+
+    @Test
+    fun `nearest selectable day is the start of the day itself when it is selectable`() {
+        assertEquals(
+            MAR_15_2026,
+            nearestSelectableDay(MAR_15_2026 + NOON_OFFSET_MILLIS, null, null, DatePickerDefaults.AllDates),
+        )
+    }
+
+    @Test
+    fun `nearest selectable day skips the days the rule rejects`() {
+        assertEquals(MAR_13_2026, nearestSelectableDay(MAR_14_2026, null, null, WeekdaysOnly))
+        assertEquals(MAR_16_2026, nearestSelectableDay(MAR_15_2026, null, null, WeekdaysOnly))
+    }
+
+    @Test
+    fun `nearest selectable day stays inside the bounds`() {
+        assertEquals(MAR_31_2026, nearestSelectableDay(APR_1_2026, null, MAR_31_2026, DatePickerDefaults.AllDates))
+        assertEquals(MAR_1_2026, nearestSelectableDay(FEB_28_2026, MAR_1_2026, null, DatePickerDefaults.AllDates))
+    }
+
+    @Test
+    fun `nearest selectable day is null when nothing is selectable within the search window`() {
+        assertNull(nearestSelectableDay(MAR_15_2026, null, null, NoDates, maxDistanceDays = 3))
+    }
+
+    @Test
+    fun `a picked day is kept when the bounds and the rule accept it`() {
+        assertEquals(MAR_13_2026, resolvePickedDay(MAR_13_2026, DateBounds(MAR_1_2026, MAR_31_2026), WeekdaysOnly))
+    }
+
+    @Test
+    fun `a rejected pick resolves to the nearest selectable day`() {
+        assertEquals(MAR_13_2026, resolvePickedDay(MAR_14_2026, DateBounds(), WeekdaysOnly))
+        assertEquals(MAR_31_2026, resolvePickedDay(APR_1_2026, DateBounds(maxDateMillis = MAR_31_2026), DatePickerDefaults.AllDates))
+    }
+
+    @Test
+    fun `a rejected pick is kept when nothing selectable is within reach`() {
+        assertEquals(MAR_14_2026, resolvePickedDay(MAR_14_2026, DateBounds(), NoDates))
+    }
+}

--- a/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/TestDates.kt
+++ b/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/TestDates.kt
@@ -1,0 +1,42 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+
+/** UTC start-of-day timestamp for the given number of days since 1970-01-01. */
+internal fun utcDay(daysSinceEpoch: Long): Long = daysSinceEpoch * MILLIS_PER_DAY
+
+internal const val NOON_OFFSET_MILLIS = 12L * 60 * 60 * 1000
+
+// Day counts since 1970-01-01 (UTC) for the dates used in the date picker tests.
+// 2026-03-01 is a Sunday, so 2026-03-14 is a Saturday and 2026-03-15 a Sunday.
+internal val FEB_29_2000 = utcDay(11016)
+internal val JAN_1_2025 = utcDay(20089)
+internal val FEB_28_2026 = utcDay(20512)
+internal val MAR_1_2026 = utcDay(20513)
+internal val MAR_13_2026 = utcDay(20525)
+internal val MAR_14_2026 = utcDay(20526)
+internal val MAR_15_2026 = utcDay(20527)
+internal val MAR_16_2026 = utcDay(20528)
+internal val MAR_31_2026 = utcDay(20543)
+internal val APR_1_2026 = utcDay(20544)
+
+private const val DAYS_PER_WEEK = 7L
+private const val EPOCH_DAY_OFFSET_FROM_MONDAY = 3L // 1970-01-01 was a Thursday
+private const val SATURDAY_INDEX = 5L
+
+/** Accepts Monday to Friday only, computed from the epoch day without a calendar library. */
+@OptIn(ExperimentalMaterial3Api::class)
+internal object WeekdaysOnly : SelectableDates {
+    override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+        val dayOfWeekIndex = (utcTimeMillis.floorDiv(MILLIS_PER_DAY) + EPOCH_DAY_OFFSET_FROM_MONDAY)
+            .mod(DAYS_PER_WEEK)
+        return dayOfWeekIndex < SATURDAY_INDEX
+    }
+}
+
+/** Rejects every day. */
+@OptIn(ExperimentalMaterial3Api::class)
+internal object NoDates : SelectableDates {
+    override fun isSelectableDate(utcTimeMillis: Long): Boolean = false
+}

--- a/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerStateMaterialTest.kt
+++ b/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerStateMaterialTest.kt
@@ -1,0 +1,172 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DisplayMode
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.SaverScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
+class AdaptiveDatePickerStateMaterialTest {
+
+    private val march = DateBounds(minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026)
+
+    private fun state(
+        selectableDates: SelectableDates = DatePickerDefaults.AllDates,
+    ) = AdaptiveDatePickerState(
+        initialSelectedDateMillis = null,
+        initialDisplayedMonthMillis = null,
+        yearRange = DatePickerDefaults.YearRange,
+        initialMaterialDisplayMode = DisplayMode.Picker,
+        initialUIKitDisplayMode = UIKitDisplayMode.Picker,
+        selectableDates = selectableDates,
+    )
+
+    @Test
+    fun `material selectable dates follow the rule`() {
+        val selectable = state(selectableDates = march).datePickerState.selectableDates
+
+        assertFalse(selectable.isSelectableDate(FEB_28_2026))
+        assertTrue(selectable.isSelectableDate(MAR_1_2026))
+        assertTrue(selectable.isSelectableDate(MAR_31_2026))
+        assertFalse(selectable.isSelectableDate(APR_1_2026))
+        assertFalse(selectable.isSelectableYear(2025))
+        assertTrue(selectable.isSelectableYear(2026))
+        assertFalse(selectable.isSelectableYear(2027))
+    }
+
+    @Test
+    fun `the material state exposes the current rule as a new object after a change`() {
+        val state = state()
+        val before = state.datePickerState.selectableDates
+        assertTrue(before.isSelectableDate(FEB_28_2026))
+
+        state.selectableDates = DateBounds(minDateMillis = MAR_1_2026)
+
+        val after = state.datePickerState.selectableDates
+        assertFalse(after.isSelectableDate(FEB_28_2026))
+        assertTrue(before !== after)
+    }
+
+    @Test
+    fun `changing the rule disables the rejected days in the calendar`() = runComposeUiTest {
+        var rule: SelectableDates by mutableStateOf(DatePickerDefaults.AllDates)
+        setContent {
+            val state = rememberAdaptiveDatePickerState(
+                initialSelectedDateMillis = MAR_15_2026,
+                selectableDates = rule,
+            )
+            AdaptiveDatePicker(state = state)
+        }
+        waitForIdle()
+        dayCell(MAR_14_2026).assertIsEnabled()
+
+        rule = WeekdaysOnly
+        waitForIdle()
+
+        dayCell(MAR_14_2026).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `selection is clamped to the new maximum when the bounds shrink`() {
+        val state = state()
+        state.selectedDateMillis = MAR_15_2026
+
+        state.selectableDates = DateBounds(maxDateMillis = MAR_1_2026)
+
+        assertEquals(MAR_1_2026, state.selectedDateMillis)
+    }
+
+    @Test
+    fun `selection is clamped to the new minimum when the bounds shrink`() {
+        val state = state()
+        state.selectedDateMillis = FEB_28_2026
+
+        state.selectableDates = DateBounds(minDateMillis = MAR_1_2026)
+
+        assertEquals(MAR_1_2026, state.selectedDateMillis)
+    }
+
+    @Test
+    fun `selection inside the bounds is left untouched`() {
+        val state = state()
+        state.selectedDateMillis = MAR_15_2026
+
+        state.selectableDates = march
+
+        assertEquals(MAR_15_2026, state.selectedDateMillis)
+    }
+
+    @Test
+    fun `selection snaps to the nearest selectable day when the rule changes`() {
+        val state = state()
+        state.selectedDateMillis = MAR_14_2026
+
+        state.selectableDates = WeekdaysOnly
+
+        assertEquals(MAR_13_2026, state.selectedDateMillis)
+    }
+
+    @Test
+    fun `selection is kept when no selectable day is within reach`() {
+        val state = state()
+        state.selectedDateMillis = MAR_14_2026
+
+        state.selectableDates = NoDates
+
+        assertEquals(MAR_14_2026, state.selectedDateMillis)
+    }
+
+    @Test
+    fun `saver round-trips the selection and re-attaches the rule`() {
+        val saver = AdaptiveDatePickerState.Saver(march)
+        val original = state(selectableDates = march)
+        original.selectedDateMillis = MAR_15_2026
+
+        val saved = requireNotNull(with(saver) { SaverScope { true }.save(original) })
+        val restored = requireNotNull(saver.restore(saved))
+
+        assertEquals(MAR_15_2026, restored.selectedDateMillis)
+        assertEquals(march, restored.selectableDates)
+    }
+
+    @Test
+    fun `saver restores a list saved by the previous format`() {
+        val savedPreviously = listOf<Any?>(MAR_15_2026, 2020, 2030, 0, 0)
+
+        val restored = requireNotNull(AdaptiveDatePickerState.Saver().restore(savedPreviously))
+
+        assertEquals(MAR_15_2026, restored.selectedDateMillis)
+        assertEquals(DatePickerDefaults.AllDates, restored.selectableDates)
+    }
+
+    @Test
+    fun `remembered state follows a new rule passed on recomposition`() = runComposeUiTest {
+        var rule: SelectableDates by mutableStateOf(DatePickerDefaults.AllDates)
+        lateinit var state: AdaptiveDatePickerState
+
+        setContent {
+            state = rememberAdaptiveDatePickerState(selectableDates = rule)
+        }
+        waitForIdle()
+        assertTrue(state.selectableDates.isSelectableDate(FEB_28_2026))
+
+        rule = march
+        waitForIdle()
+
+        assertEquals(march, state.selectableDates)
+        assertNull(state.selectedDateMillis)
+    }
+}

--- a/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DayCells.kt
+++ b/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DayCells.kt
@@ -1,0 +1,21 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+
+/** The day cell of a Material3 calendar, matched through its accessible date description. */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
+internal fun ComposeUiTest.dayCell(utcTimeMillis: Long): SemanticsNodeInteraction {
+    val description = requireNotNull(
+        DatePickerDefaults.dateFormatter()
+            .formatDate(utcTimeMillis, getCalendarLocalDefault(), forContentDescription = true),
+    )
+    val describesDay = hasText(description, substring = true) or hasContentDescription(description, substring = true)
+    return onNode(describesDay and hasClickAction())
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePicker.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePicker.ios.kt
@@ -21,7 +21,6 @@ import com.mohamedrejeb.calf.core.InternalCalfApi
 import com.mohamedrejeb.calf.ui.utils.applyLayoutDirection
 import com.mohamedrejeb.calf.ui.utils.surfaceColorAtElevation
 import kotlinx.cinterop.ExperimentalForeignApi
-import platform.UIKit.UIDatePicker
 
 @OptIn(ExperimentalForeignApi::class, ExperimentalMaterial3Api::class, InternalCalfApi::class,
     ExperimentalComposeUiApi::class
@@ -36,18 +35,29 @@ actual fun AdaptiveDatePicker(
     showModeToggle: Boolean,
     colors: DatePickerColors
 ) {
-    val datePicker = remember {
-        UIDatePicker()
-    }
-
     val datePickerManager = remember {
         DatePickerManager(
             initialSelectedDateMillis = state.selectedDateMillis,
-            datePicker = datePicker,
             displayMode = state.initialUIKitDisplayMode,
             onSelectionChanged = { dateMillis ->
                 state.selectedDateMillis = dateMillis
-            }
+            },
+            isDaySelectable = { dateMillis ->
+                state.isDaySelectable(dateMillis)
+            },
+            resolveSelection = { pickedMillis ->
+                if (state.isDaySelectable(pickedMillis)) {
+                    pickedMillis
+                } else {
+                    val bounds = state.dateBounds
+                    nearestSelectableDay(
+                        utcTimeMillis = pickedMillis,
+                        minDateMillis = bounds.minDateMillis,
+                        maxDateMillis = bounds.maxDateMillis,
+                        selectableDates = state.selectableDates,
+                    ) ?: pickedMillis
+                }
+            },
         )
     }
 
@@ -62,7 +72,20 @@ actual fun AdaptiveDatePicker(
         )
 
     LaunchedEffect(layoutDirection) {
-        datePicker.applyLayoutDirection(layoutDirection)
+        datePickerManager.view.applyLayoutDirection(layoutDirection)
+    }
+
+    LaunchedEffect(state.selectableDates) {
+        val bounds = state.dateBounds
+        datePickerManager.applyDateBounds(
+            minDateMillis = bounds.minDateMillis,
+            maxDateMillis = bounds.maxDateMillis,
+        )
+        datePickerManager.updateSelectableDates()
+    }
+
+    LaunchedEffect(state.selectedDateMillis) {
+        datePickerManager.setSelectedDate(state.selectedDateMillis)
     }
 
     LaunchedEffect(colors, containerColorAtElevation) {
@@ -78,7 +101,7 @@ actual fun AdaptiveDatePicker(
     ) {
         UIKitView(
             factory = {
-                datePicker
+                datePickerManager.view
             },
             properties = UIKitInteropProperties(
                 interactionMode = UIKitInteropInteractionMode.NonCooperative,

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerState.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerState.ios.kt
@@ -3,6 +3,7 @@ package com.mohamedrejeb.calf.ui.datepicker
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
 import com.mohamedrejeb.calf.ui.utils.datetime.KotlinxDatetimeCalendarModel
 import platform.Foundation.currentLocale
 
@@ -23,6 +24,8 @@ import platform.Foundation.currentLocale
  * @param yearRange an [IntRange] that holds the year range that the date picker will be limited
  * to
  * @param initialMaterialDisplayMode an initial [DisplayMode] that this state will hold
+ * @param initialUIKitDisplayMode an initial [UIKitDisplayMode] used by the iOS picker
+ * @param selectableDates initial value of [selectableDates]
  * @see rememberAdaptiveDatePickerState
  * @throws [IllegalArgumentException] if the initial selected date or displayed month represent
  * a year that is out of the year range.
@@ -35,6 +38,7 @@ actual class AdaptiveDatePickerState actual constructor(
     val yearRange: IntRange,
     val initialMaterialDisplayMode: DisplayMode,
     val initialUIKitDisplayMode: UIKitDisplayMode,
+    selectableDates: SelectableDates,
 ) {
     /**
      * A timestamp that represents the _start_ of the day of the selected date in _UTC_ milliseconds
@@ -74,12 +78,23 @@ actual class AdaptiveDatePickerState actual constructor(
      */
     actual var displayMode: DisplayMode = initialMaterialDisplayMode
 
+    private val selectableDatesState = mutableStateOf(selectableDates)
+
+    actual var selectableDates: SelectableDates
+        get() = selectableDatesState.value
+        set(value) {
+            selectableDatesState.value = value
+            snapSelectionToSelectable()
+        }
+
     actual companion object {
         /**
-         * The default [Saver] implementation for [DatePickerState].
+         * The default [Saver] implementation for [AdaptiveDatePickerState].
+         *
+         * @param selectableDates the rule to re-attach on restore, since it cannot be saved.
          */
-        actual fun Saver(): Saver<AdaptiveDatePickerState, *> =
-            Saver(
+        actual fun Saver(selectableDates: SelectableDates): Saver<AdaptiveDatePickerState, Any> =
+            listSaver(
                 save = {
                     listOf(
                         it.selectedDateMillis,
@@ -96,6 +111,7 @@ actual class AdaptiveDatePickerState actual constructor(
                         yearRange = IntRange(value[1] as Int, value[2] as Int),
                         initialMaterialDisplayMode = displayModeFromValue(value[3] as Int),
                         initialUIKitDisplayMode = uiKitDisplayModeFromValue(value[4] as Int),
+                        selectableDates = selectableDates,
                     )
                 },
             )

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarDatePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarDatePickerBackend.kt
@@ -1,0 +1,150 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.mohamedrejeb.calf.ui.datepicker
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCSignatureOverride
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateComponents
+import platform.Foundation.NSDateInterval
+import platform.Foundation.NSTimeZone
+import platform.Foundation.distantFuture
+import platform.Foundation.distantPast
+import platform.Foundation.localTimeZone
+import platform.UIKit.UICalendarSelectionSingleDate
+import platform.UIKit.UICalendarSelectionSingleDateDelegateProtocol
+import platform.UIKit.UICalendarView
+import platform.UIKit.UICalendarViewDecoration
+import platform.UIKit.UICalendarViewDelegateProtocol
+import platform.UIKit.UIColor
+import platform.UIKit.UIView
+import platform.darwin.NSObject
+
+private const val MAX_SUPPORTED_YEAR = 9999L
+private const val MAX_MONTH = 12L
+
+/**
+ * Inline calendar backed by `UICalendarView` (iOS 16+). Days rejected by [isDaySelectable]
+ * are greyed out and cannot be tapped, matching the Material picker.
+ */
+internal class CalendarDatePickerBackend(
+    initialSelectedDateMillis: Long?,
+    private val onSelectionChanged: (utcTimeMillis: Long?) -> Unit,
+    private val isDaySelectable: (utcTimeMillis: Long) -> Boolean,
+) : IosDatePickerBackend {
+
+    private val calendarView = UICalendarView()
+
+    private val selectionDelegate = object : NSObject(), UICalendarSelectionSingleDateDelegateProtocol {
+        @ObjCSignatureOverride
+        override fun dateSelection(
+            selection: UICalendarSelectionSingleDate,
+            didSelectDate: NSDateComponents?,
+        ) {
+            onSelectionChanged(didSelectDate?.toUtcDayMillis())
+        }
+
+        @ObjCSignatureOverride
+        override fun dateSelection(
+            selection: UICalendarSelectionSingleDate,
+            canSelectDate: NSDateComponents?,
+        ): Boolean {
+            val day = canSelectDate?.toUtcDayMillis() ?: return true
+            return isDaySelectable(day)
+        }
+    }
+
+    private val selection = UICalendarSelectionSingleDate(delegate = selectionDelegate)
+
+    /** Draws no decorations, but lets [refresh] ask the calendar to rebuild its day cells. */
+    private val decorationDelegate = object : NSObject(), UICalendarViewDelegateProtocol {
+        @ObjCSignatureOverride
+        override fun calendarView(
+            calendarView: UICalendarView,
+            decorationForDateComponents: NSDateComponents,
+        ): UICalendarViewDecoration? = null
+    }
+
+    override val view: UIView
+        get() = calendarView
+
+    init {
+        calendarView.calendar = NSCalendar.currentCalendar
+        calendarView.locale = getCalendarLocalDefault()
+        calendarView.timeZone = NSTimeZone.localTimeZone
+        calendarView.delegate = decorationDelegate
+        calendarView.selectionBehavior = selection
+        initialSelectedDateMillis?.let { millis ->
+            selection.setSelectedDate(utcDayToDateComponents(millis), animated = false)
+            calendarView.setVisibleDateComponents(utcDayToDateComponents(millis), animated = false)
+        }
+        calendarView.sizeToFit()
+    }
+
+    override fun setSelectedDate(utcTimeMillis: Long?) {
+        val current = selection.selectedDate?.toUtcDayMillis()
+        if (current == utcTimeMillis) return
+
+        selection.setSelectedDate(utcTimeMillis?.let(::utcDayToDateComponents), animated = true)
+        utcTimeMillis?.let { millis ->
+            calendarView.setVisibleDateComponents(utcDayToDateComponents(millis), animated = true)
+        }
+    }
+
+    override fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?) {
+        val start = minDateMillis?.let(::localStartOfDay) ?: NSDate.distantPast
+        val end = maxDateMillis?.let(::localEndOfDay) ?: NSDate.distantFuture
+        calendarView.availableDateRange = NSDateInterval(startDate = start, endDate = end)
+    }
+
+    override fun updateSelectableDates() {
+        selection.updateSelectableDates()
+        refresh()
+    }
+
+    /**
+     * Rebuilds the days around the visible month, so bounds and rule changes show right away
+     * instead of on the next scroll or tap.
+     */
+    private fun refresh() {
+        val days = daysAroundVisibleMonth()
+        if (days.isNotEmpty()) {
+            calendarView.reloadDecorationsForDateComponents(days, animated = false)
+        }
+        calendarView.setNeedsLayout()
+        calendarView.layoutIfNeeded()
+    }
+
+    /** Every day of the visible month and its two neighbours, which may be partly on screen. */
+    private fun daysAroundVisibleMonth(): List<NSDateComponents> {
+        val visible = calendarView.visibleDateComponents
+        val year = visible.year
+        val month = visible.month
+        if (year !in 1..MAX_SUPPORTED_YEAR || month !in 1..MAX_MONTH) return emptyList()
+
+        val firstOfMonth = LocalDate(year.toInt(), month.toInt(), 1)
+        val start = firstOfMonth.minus(1, DateTimeUnit.MONTH)
+        val end = firstOfMonth.plus(2, DateTimeUnit.MONTH)
+        return generateSequence(start) { it.plus(1, DateTimeUnit.DAY) }
+            .takeWhile { it < end }
+            .map { date ->
+                NSDateComponents().apply {
+                    this.year = date.year.toLong()
+                    this.month = date.month.number.toLong()
+                    this.day = date.day.toLong()
+                }
+            }
+            .toList()
+    }
+
+    override fun applyColors(containerColor: UIColor, selectedDayContainerColor: UIColor) {
+        calendarView.tintColor = selectedDayContainerColor
+        calendarView.backgroundColor = containerColor
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateConversions.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateConversions.kt
@@ -1,0 +1,76 @@
+@file:OptIn(ExperimentalTime::class, ExperimentalForeignApi::class)
+
+package com.mohamedrejeb.calf.ui.datepicker
+
+import com.mohamedrejeb.calf.ui.utils.datetime.KotlinxDatetimeCalendarModel
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateComponents
+import platform.Foundation.NSDayCalendarUnit
+import platform.Foundation.NSMonthCalendarUnit
+import platform.Foundation.NSYearCalendarUnit
+import platform.Foundation.dateWithTimeIntervalSince1970
+import kotlin.time.ExperimentalTime
+
+private val calendarModel = KotlinxDatetimeCalendarModel()
+
+private const val MILLIS_PER_SECOND = 1000.0
+
+/** The calendar day of a UTC day timestamp, as a plain date. */
+internal fun utcDayToLocalDate(utcTimeMillis: Long): LocalDate {
+    val canonicalDate = calendarModel.getCanonicalDate(utcTimeMillis)
+    return LocalDate(
+        year = canonicalDate.year,
+        month = canonicalDate.month,
+        day = canonicalDate.dayOfMonth,
+    )
+}
+
+/** Start of the same calendar day in the device time zone. */
+internal fun localStartOfDay(utcTimeMillis: Long): NSDate {
+    val startMillis = utcDayToLocalDate(utcTimeMillis)
+        .atStartOfDayIn(TimeZone.currentSystemDefault())
+        .toEpochMilliseconds()
+    return NSDate.dateWithTimeIntervalSince1970(startMillis / MILLIS_PER_SECOND)
+}
+
+/** Last millisecond of the same calendar day in the device time zone. */
+internal fun localEndOfDay(utcTimeMillis: Long): NSDate {
+    val nextDayStartMillis = utcDayToLocalDate(utcTimeMillis)
+        .plus(1, DateTimeUnit.DAY)
+        .atStartOfDayIn(TimeZone.currentSystemDefault())
+        .toEpochMilliseconds()
+    return NSDate.dateWithTimeIntervalSince1970((nextDayStartMillis - 1) / MILLIS_PER_SECOND)
+}
+
+/** The UTC start of the calendar day this date falls on in the device time zone. */
+internal fun NSDate.toUtcDayMillis(): Long {
+    val components = NSCalendar.currentCalendar.components(
+        NSYearCalendarUnit or NSMonthCalendarUnit or NSDayCalendarUnit,
+        this,
+    )
+    return components.toUtcDayMillis()
+}
+
+/** The UTC start of the day described by year, month and day components. */
+internal fun NSDateComponents.toUtcDayMillis(): Long =
+    LocalDate(year = year.toInt(), month = month.toInt(), day = day.toInt())
+        .atStartOfDayIn(TimeZone.UTC)
+        .toEpochMilliseconds()
+
+/** Year, month and day components for a UTC day timestamp. */
+internal fun utcDayToDateComponents(utcTimeMillis: Long): NSDateComponents {
+    val date = utcDayToLocalDate(utcTimeMillis)
+    return NSDateComponents().apply {
+        year = date.year.toLong()
+        month = date.month.number.toLong()
+        day = date.day.toLong()
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DatePickerManager.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DatePickerManager.kt
@@ -1,4 +1,4 @@
-@file:OptIn(BetaInteropApi::class)
+@file:OptIn(ExperimentalForeignApi::class)
 
 package com.mohamedrejeb.calf.ui.datepicker
 
@@ -8,106 +8,64 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import com.mohamedrejeb.calf.core.InternalCalfApi
 import com.mohamedrejeb.calf.ui.utils.applyTheme
-import com.mohamedrejeb.calf.ui.utils.datetime.KotlinxDatetimeCalendarModel
 import com.mohamedrejeb.calf.ui.utils.isDark
+import com.mohamedrejeb.calf.ui.utils.isIOSVersionAtLeast
 import com.mohamedrejeb.calf.ui.utils.toUIColor
-import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.toNSTimeZone
-import platform.Foundation.NSCalendar
-import platform.Foundation.NSDate
-import platform.Foundation.NSDayCalendarUnit
-import platform.Foundation.NSMonthCalendarUnit
-import platform.Foundation.NSYearCalendarUnit
-import platform.Foundation.dateWithTimeIntervalSince1970
-import platform.UIKit.UIControlEventValueChanged
 import platform.UIKit.UIDatePicker
 import platform.UIKit.UIDatePickerMode
 import platform.UIKit.UIDatePickerStyle
-import platform.darwin.NSObject
-import platform.objc.sel_registerName
-import kotlin.time.ExperimentalTime
+import platform.UIKit.UIView
 
-@OptIn(
-    ExperimentalForeignApi::class, ExperimentalTime::class,
-)
+private const val FIRST_IOS_WITH_CALENDAR_VIEW = 16
+
+/**
+ * Owns the native date picker view and keeps it in sync with [AdaptiveDatePickerState].
+ *
+ * The inline style uses `UICalendarView` on iOS 16+, which can grey out days the
+ * [isDaySelectable] rule rejects. The wheels style, and the inline style on older systems,
+ * use `UIDatePicker` and resolve rejected picks through [resolveSelection].
+ */
 @InternalCalfApi
 class DatePickerManager internal constructor(
     initialSelectedDateMillis: Long?,
-    private val datePicker: UIDatePicker,
     displayMode: UIKitDisplayMode,
-    private val onSelectionChanged: (dateMillis: Long?) -> Unit,
+    onSelectionChanged: (utcTimeMillis: Long?) -> Unit,
+    isDaySelectable: (utcTimeMillis: Long) -> Boolean,
+    resolveSelection: (pickedUtcTimeMillis: Long) -> Long,
 ) {
-    private val calendarModel = KotlinxDatetimeCalendarModel()
-
-    @OptIn(ExperimentalTime::class)
-    private val datePickerDelegate = object : NSObject() {
-        @Suppress("unused")
-        @ObjCAction
-        fun onDateChanged(sender: UIDatePicker) {
-            val components = NSCalendar.currentCalendar.components(
-                NSYearCalendarUnit or NSMonthCalendarUnit or NSDayCalendarUnit,
-                sender.date
+    private val backend: IosDatePickerBackend =
+        if (displayMode == UIKitDisplayMode.Picker && isIOSVersionAtLeast(FIRST_IOS_WITH_CALENDAR_VIEW)) {
+            CalendarDatePickerBackend(
+                initialSelectedDateMillis = initialSelectedDateMillis,
+                onSelectionChanged = onSelectionChanged,
+                isDaySelectable = isDaySelectable,
             )
-
-            val utcTimeMillis =
-                LocalDate(
-                    year = components.year.toInt(),
-                    month = components.month.toInt(),
-                    day = components.day.toInt()
-                )
-                    .atStartOfDayIn(TimeZone.UTC)
-                    .toEpochMilliseconds()
-
-            onSelectionChanged(utcTimeMillis)
+        } else {
+            WheelsDatePickerBackend(
+                initialSelectedDateMillis = initialSelectedDateMillis,
+                style = when (displayMode) {
+                    UIKitDisplayMode.Picker -> UIDatePickerStyle.UIDatePickerStyleInline
+                    else -> UIDatePickerStyle.UIDatePickerStyleWheels
+                },
+                onSelectionChanged = onSelectionChanged,
+                resolveSelection = resolveSelection,
+            )
         }
-    }
 
+    /** The native view to embed. */
+    val view: UIView
+        get() = backend.view
+
+    /** Width divided by height of the native view, or 0 when it has no intrinsic size yet. */
     internal var aspectRatio by mutableFloatStateOf(0f)
         private set
 
     init {
-        val date =
-            if (initialSelectedDateMillis != null) {
-                val canonicalDate = calendarModel.getCanonicalDate(initialSelectedDateMillis)
-                val currentTimeZoneTimeMillis =
-                    LocalDate(
-                        year = canonicalDate.year,
-                        month = canonicalDate.month,
-                        day = canonicalDate.dayOfMonth
-                    )
-                        .atStartOfDayIn(TimeZone.currentSystemDefault())
-                        .toEpochMilliseconds()
-
-                NSDate.dateWithTimeIntervalSince1970(currentTimeZoneTimeMillis / 1000.0)
-            } else {
-                NSDate()
-            }
-
-        datePicker.setDate(date, animated = false)
-        datePicker.locale = getCalendarLocalDefault()
-        datePicker.timeZone = TimeZone.currentSystemDefault().toNSTimeZone()
-        datePicker.datePickerMode = UIDatePickerMode.UIDatePickerModeDate
-        datePicker.preferredDatePickerStyle = when (displayMode) {
-            UIKitDisplayMode.Picker -> UIDatePickerStyle.UIDatePickerStyleInline
-            else -> UIDatePickerStyle.UIDatePickerStyleWheels
-        }
-
-        // Add target using NSObject delegate
-        datePicker.addTarget(
-            target = datePickerDelegate,
-            action = sel_registerName("onDateChanged:"),
-            forControlEvents = UIControlEventValueChanged
-        )
-
-        datePicker.frame.useContents {
-            aspectRatio = this.size.width.toFloat() / this.size.height.toFloat()
-        }
+        aspectRatio = backend.view.aspectRatioOrZero()
+            .takeIf { it > 0f }
+            ?: inlineDatePickerAspectRatio()
     }
 
     internal fun applyColors(
@@ -116,11 +74,38 @@ class DatePickerManager internal constructor(
         selectedDayContainerColor: Color,
     ) {
         applyTheme(isDark = !isDark(dayContentColor))
-        datePicker.tintColor = selectedDayContainerColor.toUIColor()
-        datePicker.backgroundColor = containerColor.toUIColor()
+        backend.applyColors(
+            containerColor = containerColor.toUIColor(),
+            selectedDayContainerColor = selectedDayContainerColor.toUIColor(),
+        )
     }
 
     internal fun applyTheme(isDark: Boolean) {
-        datePicker.applyTheme(isDark)
+        backend.view.applyTheme(isDark)
+    }
+
+    internal fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?) {
+        backend.applyDateBounds(minDateMillis, maxDateMillis)
+        backend.updateSelectableDates()
+    }
+
+    internal fun updateSelectableDates() {
+        backend.updateSelectableDates()
+    }
+
+    internal fun setSelectedDate(utcTimeMillis: Long?) {
+        backend.setSelectedDate(utcTimeMillis)
     }
 }
+
+private fun UIView.aspectRatioOrZero(): Float =
+    frame.useContents {
+        if (size.height > 0.0) (size.width / size.height).toFloat() else 0f
+    }
+
+/** Size of a stock inline `UIDatePicker`, used when the calendar view reports no size yet. */
+private fun inlineDatePickerAspectRatio(): Float =
+    UIDatePicker().apply {
+        datePickerMode = UIDatePickerMode.UIDatePickerModeDate
+        preferredDatePickerStyle = UIDatePickerStyle.UIDatePickerStyleInline
+    }.aspectRatioOrZero()

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/IosDatePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/IosDatePickerBackend.kt
@@ -1,0 +1,23 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import platform.UIKit.UIColor
+import platform.UIKit.UIView
+
+/**
+ * A native view that lets the user pick a day, driven by [DatePickerManager].
+ */
+internal interface IosDatePickerBackend {
+    /** The view to embed in the Compose hierarchy. */
+    val view: UIView
+
+    /** Shows [utcTimeMillis] as the selection without notifying the selection callback. */
+    fun setSelectedDate(utcTimeMillis: Long?)
+
+    /** Restricts the pickable range; a null bound is open on that side. */
+    fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?)
+
+    /** Re-evaluates which days can be picked after the rule or the bounds changed. */
+    fun updateSelectableDates()
+
+    fun applyColors(containerColor: UIColor, selectedDayContainerColor: UIColor)
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/WheelsDatePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/WheelsDatePickerBackend.kt
@@ -1,0 +1,83 @@
+@file:OptIn(BetaInteropApi::class, ExperimentalForeignApi::class)
+
+package com.mohamedrejeb.calf.ui.datepicker
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCAction
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toNSTimeZone
+import platform.Foundation.NSDate
+import platform.UIKit.UIColor
+import platform.UIKit.UIControlEventValueChanged
+import platform.UIKit.UIDatePicker
+import platform.UIKit.UIDatePickerMode
+import platform.UIKit.UIDatePickerStyle
+import platform.UIKit.UIView
+import platform.darwin.NSObject
+import platform.objc.sel_registerName
+
+/**
+ * Picker backed by `UIDatePicker`, used for the wheels style and as the inline fallback below
+ * iOS 16. `UIDatePicker` can only enforce a minimum and a maximum date, so a picked day the
+ * rule rejects is replaced by [resolveSelection] and the wheels move to that day.
+ */
+internal class WheelsDatePickerBackend(
+    initialSelectedDateMillis: Long?,
+    style: UIDatePickerStyle,
+    private val onSelectionChanged: (utcTimeMillis: Long?) -> Unit,
+    private val resolveSelection: (pickedUtcTimeMillis: Long) -> Long,
+) : IosDatePickerBackend {
+
+    private val datePicker = UIDatePicker()
+
+    private val valueChangedTarget = object : NSObject() {
+        @Suppress("unused")
+        @ObjCAction
+        fun onDateChanged(sender: UIDatePicker) {
+            val picked = sender.date.toUtcDayMillis()
+            val resolved = resolveSelection(picked)
+            if (resolved != picked) {
+                sender.setDate(localStartOfDay(resolved), animated = true)
+            }
+            onSelectionChanged(resolved)
+        }
+    }
+
+    override val view: UIView
+        get() = datePicker
+
+    init {
+        datePicker.setDate(initialSelectedDateMillis?.let(::localStartOfDay) ?: NSDate(), animated = false)
+        datePicker.locale = getCalendarLocalDefault()
+        datePicker.timeZone = TimeZone.currentSystemDefault().toNSTimeZone()
+        datePicker.datePickerMode = UIDatePickerMode.UIDatePickerModeDate
+        datePicker.preferredDatePickerStyle = style
+        datePicker.addTarget(
+            target = valueChangedTarget,
+            action = sel_registerName("onDateChanged:"),
+            forControlEvents = UIControlEventValueChanged,
+        )
+    }
+
+    override fun setSelectedDate(utcTimeMillis: Long?) {
+        // The wheels always show a date, so a cleared selection leaves them where they are.
+        val target = utcTimeMillis ?: return
+        if (datePicker.date.toUtcDayMillis() == target) return
+        datePicker.setDate(localStartOfDay(target), animated = true)
+    }
+
+    override fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?) {
+        datePicker.minimumDate = minDateMillis?.let(::localStartOfDay)
+        datePicker.maximumDate = maxDateMillis?.let(::localEndOfDay)
+    }
+
+    override fun updateSelectableDates() {
+        // UIDatePicker cannot grey out individual days; rejected picks are resolved on change.
+    }
+
+    override fun applyColors(containerColor: UIColor, selectedDayContainerColor: UIColor) {
+        datePicker.tintColor = selectedDayContainerColor
+        datePicker.backgroundColor = containerColor
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/utils/SystemUtils.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/utils/SystemUtils.kt
@@ -2,8 +2,11 @@ package com.mohamedrejeb.calf.ui.utils
 
 import platform.UIKit.UIDevice
 
-internal fun isIOS26OrAbove(): Boolean {
+/** True when the device runs iOS [major] or newer. */
+internal fun isIOSVersionAtLeast(major: Int): Boolean {
     val systemVersion = UIDevice.currentDevice.systemVersion
-    val major = systemVersion.split(".").firstOrNull()?.toIntOrNull() ?: 0
-    return major >= 26
+    val current = systemVersion.split(".").firstOrNull()?.toIntOrNull() ?: 0
+    return current >= major
 }
+
+internal fun isIOS26OrAbove(): Boolean = isIOSVersionAtLeast(26)

--- a/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerState.material.kt
+++ b/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePickerState.material.kt
@@ -3,8 +3,11 @@ package com.mohamedrejeb.calf.ui.datepicker
 import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
 
 /**
  * A state object that can be hoisted to observe the date picker state. See
@@ -23,6 +26,8 @@ import androidx.compose.runtime.saveable.Saver
  * @param yearRange an [IntRange] that holds the year range that the date picker will be limited
  * to
  * @param initialMaterialDisplayMode an initial [DisplayMode] that this state will hold
+ * @param initialUIKitDisplayMode an initial [UIKitDisplayMode] used by the iOS picker
+ * @param selectableDates initial value of [selectableDates]
  * @see rememberAdaptiveDatePickerState
  * @throws [IllegalArgumentException] if the initial selected date or displayed month represent
  * a year out of the year range.
@@ -35,11 +40,18 @@ actual class AdaptiveDatePickerState actual constructor(
     val yearRange: IntRange,
     val initialMaterialDisplayMode: DisplayMode,
     val initialUIKitDisplayMode: UIKitDisplayMode,
+    selectableDates: SelectableDates,
 ) {
-    /**
-     * The date picker state that this state holds.
-     */
-    val datePickerState: DatePickerState =
+    private val selectableDatesState = mutableStateOf(selectableDates)
+
+    actual var selectableDates: SelectableDates
+        get() = selectableDatesState.value
+        set(value) {
+            selectableDatesState.value = value
+            snapSelectionToSelectable()
+        }
+
+    private val materialState: DatePickerState =
         DatePickerState(
             locale = getCalendarLocalDefault(),
             initialSelectedDateMillis = initialSelectedDateMillis,
@@ -47,6 +59,14 @@ actual class AdaptiveDatePickerState actual constructor(
             yearRange = yearRange,
             initialDisplayMode = initialMaterialDisplayMode,
         )
+
+    /**
+     * The Material3 date picker state that this state delegates to. It reports
+     * [selectableDates] as its rule, so the Material3 picker follows every change.
+     */
+    // `this.` is required: the constructor parameter of the same name would be captured otherwise.
+    val datePickerState: DatePickerState =
+        RuleTrackingDatePickerState(materialState) { this.selectableDates }
 
     /**
      * A timestamp that represents the _start_ of the day of the selected date in _UTC_ milliseconds
@@ -93,10 +113,12 @@ actual class AdaptiveDatePickerState actual constructor(
 
     actual companion object {
         /**
-         * The default [Saver] implementation for [DatePickerState].
+         * The default [Saver] implementation for [AdaptiveDatePickerState].
+         *
+         * @param selectableDates the rule to re-attach on restore, since it cannot be saved.
          */
-        actual fun Saver(): Saver<AdaptiveDatePickerState, *> =
-            Saver(
+        actual fun Saver(selectableDates: SelectableDates): Saver<AdaptiveDatePickerState, Any> =
+            listSaver(
                 save = {
                     listOf(
                         it.selectedDateMillis,
@@ -113,6 +135,7 @@ actual class AdaptiveDatePickerState actual constructor(
                         yearRange = IntRange(value[1] as Int, value[2] as Int),
                         initialMaterialDisplayMode = displayModeFromValue(value[3] as Int),
                         initialUIKitDisplayMode = uiKitDisplayModeFromValue(value[4] as Int),
+                        selectableDates = selectableDates,
                     )
                 },
             )

--- a/docs/ui/adaptive-date-picker.md
+++ b/docs/ui/adaptive-date-picker.md
@@ -1,57 +1,98 @@
 # Date Picker
 
-`AdaptiveDatePicker` is a date picker that adapts to the platform it is running on. It is a wrapper around `DatePicker` on Android and `UIDatePicker` on iOS, providing a native date selection experience on each platform.
-
-| Material (Android, Desktop, Web)                              | Cupertino (iOS)                                       |
-|---------------------------------------------------------------|-------------------------------------------------------|
-| ![Date Picker Android](../images/AdaptiveDatePicker-android.png) | ![Date Picker iOS](../images/AdaptiveDatePicker-ios.png) |
+`AdaptiveDatePicker` is a date picker that adapts to the platform it is running on. It is a wrapper around the Material3 `DatePicker` on Android, Desktop and Web, and around `UICalendarView` (iOS 16+) or `UIDatePicker` on iOS, providing a native date selection experience on each platform.
 
 ## Usage
 
-The `AdaptiveDatePicker` uses a state object to manage and track the selected date. You can observe changes to the selected date through the state.
+The `AdaptiveDatePicker` uses a state object to manage and track the selected date. You can observe changes to the selected date through the state. Timestamps are UTC milliseconds at the start of the selected day.
 
 ```kotlin
-// Create and remember the date picker state
-val state = rememberAdaptiveDatePickerState()
-
-// Optional: Set initial date (default is current date)
-LaunchedEffect(Unit) {
-    state.setSelection(Calendar.getInstance().apply {
-        set(2023, 0, 1) // January 1, 2023
-    }.timeInMillis)
-}
+// Create and remember the date picker state, optionally with an initial selection
+val state = rememberAdaptiveDatePickerState(
+    initialSelectedDateMillis = LocalDate(2026, 1, 1)
+        .atStartOfDayIn(TimeZone.UTC)
+        .toEpochMilliseconds(),
+)
 
 // React to date changes
 LaunchedEffect(state.selectedDateMillis) {
     val selectedDate = state.selectedDateMillis?.let { millis ->
-        Calendar.getInstance().apply {
-            timeInMillis = millis
-        }
+        Instant.fromEpochMilliseconds(millis).toLocalDateTime(TimeZone.UTC).date
     }
-
-    // Do something with the selected date
-    selectedDate?.let {
-        val year = it.get(Calendar.YEAR)
-        val month = it.get(Calendar.MONTH) + 1 // Calendar months are 0-based
-        val day = it.get(Calendar.DAY_OF_MONTH)
-        println("Selected date: $year-$month-$day")
-    }
+    println("Selected date: $selectedDate")
 }
 
 // Display the date picker
 AdaptiveDatePicker(
     state = state,
     modifier = Modifier.fillMaxWidth(),
-    // Optional: Customize date constraints
-    dateValidator = { timestamp ->
-        // Example: Only allow dates from today forward
-        timestamp >= Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 0)
-            set(Calendar.MINUTE, 0)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-        }.timeInMillis
-    }
 )
 ```
 
+The examples use [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime) for date math. Any source of UTC epoch milliseconds works.
+
+## Restricting selectable dates
+
+Every picker takes a Material3 `SelectableDates` rule through `selectableDates`. Calf ships `DateBounds` for the common case of a minimum and maximum day, and an infix `and` to combine rules.
+
+### Bounds
+
+```kotlin
+val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+
+val state = rememberAdaptiveDatePickerState(
+    selectableDates = DateBounds(
+        minDateMillis = today.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds(),
+        maxDateMillis = today.plus(30, DateTimeUnit.DAY)
+            .atStartOfDayIn(TimeZone.UTC)
+            .toEpochMilliseconds(),
+    ),
+)
+```
+
+Both bounds are inclusive and compared per UTC day, so any timestamp inside the first or last day keeps that whole day selectable. A `null` bound is open on that side. Besides greying out days, bounds are applied natively: the iOS wheels stop at the range and the calendars hide the months outside it, using the same calendar day in the device time zone. If the current selection falls outside a new range, it is moved to the nearest selectable day on every platform.
+
+The rule is an observable property of the state, so it can depend on other state. A typical case is a date range where the end date cannot come before the start date:
+
+```kotlin
+val startState = rememberAdaptiveDatePickerState()
+val endState = rememberAdaptiveDatePickerState(
+    selectableDates = DateBounds(minDateMillis = startState.selectedDateMillis),
+)
+```
+
+`DateBounds` is a data class, so passing an equal value on recomposition changes nothing.
+
+### Rules for individual days
+
+Rules that a min/max range cannot express, such as excluding weekends, are plain `SelectableDates` implementations. Combine them with bounds using `and`:
+
+```kotlin
+val weekdaysOnly = remember {
+    object : SelectableDates {
+        override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+            val day = Instant.fromEpochMilliseconds(utcTimeMillis)
+                .toLocalDateTime(TimeZone.UTC)
+                .date
+                .dayOfWeek
+            return day != DayOfWeek.SATURDAY && day != DayOfWeek.SUNDAY
+        }
+    }
+}
+
+val state = rememberAdaptiveDatePickerState(
+    selectableDates = DateBounds(minDateMillis = todayMillis) and weekdaysOnly,
+)
+```
+
+Pass a stable instance, such as an `object`, a data class or a remembered value, so the picker is not re-evaluated on every recomposition.
+
+| Platform | Behaviour |
+|---|---|
+| Material (Android, Desktop, Web) | Rejected days are disabled in the calendar grid. `isSelectableYear` disables years in the year picker. |
+| iOS 16+ inline calendar (`UIKitDisplayMode.Picker`) | Backed by `UICalendarView`: rejected days are greyed out and cannot be tapped. Bounds coming from a `DateBounds` also hide the months outside the range. |
+| iOS wheels (`UIKitDisplayMode.Wheels`) and inline below iOS 16 | Backed by `UIDatePicker`, which cannot grey out days. Bounds coming from a `DateBounds` stop the wheels at the range; picking any other rejected day snaps the wheels to the nearest selectable day. |
+
+On every platform, a current selection that a new rule rejects is moved to the nearest selectable day. `isSelectableYear` has no effect on iOS.
+
+> `AdaptiveDatePicker` has no `dateValidator` parameter. An earlier version of this page documented one that never existed. Use `selectableDates` with `DateBounds` as described above instead.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ vanniktech-maven-publish = { module = "com.vanniktech.maven.publish:com.vannikte
 compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "compose" }
 compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "compose" }
 compose-ui-graphics = { group = "org.jetbrains.compose.ui", name = "ui-graphics", version.ref = "compose" }
+compose-ui-test = { group = "org.jetbrains.compose.ui", name = "ui-test", version.ref = "compose" }
 compose-components-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "compose" }
 compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "material3" }
 compose-material-icons-extended = { group = "org.jetbrains.compose.material", name = "material-icons-extended", version.ref = "material-icons-extended" }

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/DatePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/DatePickerScreen.kt
@@ -1,37 +1,108 @@
+@file:OptIn(ExperimentalTime::class)
+
 package com.mohamedrejeb.calf.sample.screens
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DatePickerColors
 import androidx.compose.material3.DatePickerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mohamedrejeb.calf.sample.components.SampleScreenScaffold
+import com.mohamedrejeb.calf.sample.currentPlatform
 import com.mohamedrejeb.calf.ui.datepicker.AdaptiveDatePicker
+import com.mohamedrejeb.calf.ui.datepicker.DateBounds
+import com.mohamedrejeb.calf.ui.datepicker.UIKitDisplayMode
+import com.mohamedrejeb.calf.ui.datepicker.and
 import com.mohamedrejeb.calf.ui.datepicker.rememberAdaptiveDatePickerState
+import com.mohamedrejeb.calf.ui.toggle.AdaptiveSwitch
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.todayIn
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+private const val RANGE_LENGTH_DAYS = 30
+
+private enum class RangeOption(val label: String) {
+    AnyDate("Any date"),
+    FromToday("From today"),
+    NextThirtyDays("Next $RANGE_LENGTH_DAYS days"),
+}
+
+/** Rejects Saturdays and Sundays; a stable object so the pickers are not re-evaluated needlessly. */
+@OptIn(ExperimentalMaterial3Api::class)
+private object WeekdaysOnly : SelectableDates {
+    override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+        val dayOfWeek = Instant.fromEpochMilliseconds(utcTimeMillis)
+            .toLocalDateTime(TimeZone.UTC)
+            .date
+            .dayOfWeek
+        return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerScreen(
     navigateBack: () -> Unit
 ) {
-    val state = rememberAdaptiveDatePickerState()
+    var rangeOption by remember { mutableStateOf(RangeOption.AnyDate) }
+    var weekdaysOnly by remember { mutableStateOf(false) }
+
+    val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
+    val todayMillis = remember(today) {
+        today.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+    }
+    val endOfRangeMillis = remember(today) {
+        today.plus(RANGE_LENGTH_DAYS, DateTimeUnit.DAY).atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+    }
+
+    val selectableDates: SelectableDates = remember(rangeOption, weekdaysOnly, todayMillis, endOfRangeMillis) {
+        val bounds: SelectableDates = when (rangeOption) {
+            RangeOption.AnyDate -> DatePickerDefaults.AllDates
+            RangeOption.FromToday -> DateBounds(minDateMillis = todayMillis)
+            RangeOption.NextThirtyDays -> DateBounds(minDateMillis = todayMillis, maxDateMillis = endOfRangeMillis)
+        }
+        if (weekdaysOnly) bounds and WeekdaysOnly else bounds
+    }
+
+    val inlineState = rememberAdaptiveDatePickerState(selectableDates = selectableDates)
+    val wheelsState = rememberAdaptiveDatePickerState(
+        initialUIKitDisplayMode = UIKitDisplayMode.Wheels,
+        selectableDates = selectableDates,
+    )
 
     SampleScreenScaffold(
         title = "Adaptive Date Picker",
         navigateBack = navigateBack,
     ) { padding ->
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
@@ -39,7 +110,8 @@ fun DatePickerScreen(
                 .padding(16.dp)
         ) {
             Text(
-                text = "Date selection using native iOS UIDatePicker and Material3 DatePicker.",
+                text = "Date selection using the native iOS controls and the Material3 DatePicker. " +
+                    "The controls below restrict which days can be picked on both platforms.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -47,19 +119,119 @@ fun DatePickerScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             Text(
-                text = "Selected date millis: ${state.selectedDateMillis ?: "None"}",
+                text = "Selectable range",
+                style = MaterialTheme.typography.labelLarge,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+            ) {
+                RangeOption.entries.forEachIndexed { index, option ->
+                    FilterChip(
+                        selected = rangeOption == option,
+                        onClick = { rangeOption = option },
+                        label = { Text(option.label) },
+                    )
+                    if (index < RangeOption.entries.lastIndex) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Weekdays only",
+                    modifier = Modifier.weight(1f),
+                )
+                AdaptiveSwitch(
+                    checked = weekdaysOnly,
+                    onCheckedChange = { weekdaysOnly = it },
+                )
+            }
+
+            SectionDivider()
+
+            SectionTitle(
+                title = "Inline picker",
+                description = "The full calendar, always visible.",
+            )
+
+            Text(
+                text = "Selected: ${inlineState.selectedDateMillis.toDateLabel()}",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.primary,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
             AdaptiveDatePicker(
-                state = state,
-                colors = DatePickerDefaults.colors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                ),
+                state = inlineState,
+                colors = sampleDatePickerColors(),
             )
+
+            if (currentPlatform.isIOS) {
+                SectionDivider()
+
+                SectionTitle(
+                    title = "Wheels picker (iOS)",
+                    description = "UIDatePicker wheels cannot grey out days: a rejected pick snaps " +
+                        "to the nearest selectable day.",
+                )
+
+                Text(
+                    text = "Selected: ${wheelsState.selectedDateMillis.toDateLabel()}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                AdaptiveDatePicker(
+                    state = wheelsState,
+                    colors = sampleDatePickerColors(),
+                )
+            }
         }
     }
 }
+
+@Composable
+private fun SectionDivider() {
+    Spacer(modifier = Modifier.height(16.dp))
+    HorizontalDivider()
+    Spacer(modifier = Modifier.height(16.dp))
+}
+
+@Composable
+private fun SectionTitle(title: String, description: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = description,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun sampleDatePickerColors(): DatePickerColors =
+    DatePickerDefaults.colors(
+        containerColor = MaterialTheme.colorScheme.surface,
+    )
+
+private fun Long?.toDateLabel(): String =
+    this?.let { millis ->
+        Instant.fromEpochMilliseconds(millis).toLocalDateTime(TimeZone.UTC).date.toString()
+    } ?: "None"


### PR DESCRIPTION
Closes #328.

## Summary

The docs advertised a `dateValidator` parameter on `AdaptiveDatePicker` that never existed. This adds a real, cross-platform way to restrict which days can be picked.

- `AdaptiveDatePickerState` and `rememberAdaptiveDatePickerState` gain an observable `selectableDates` rule, using Material3's `SelectableDates` interface. It is the only restriction parameter.
- `DateBounds(minDateMillis, maxDateMillis)` is a `SelectableDates` for a minimum and maximum day, inclusive and compared per UTC day. An infix `and` combines rules, for example `DateBounds(minDateMillis = today) and weekdaysOnly`.
- **Material**: the Material3 state is wrapped so it reports the caller's rule object. Material3 caches each day's enabled flag keyed on that object, so a rule that changes its answers in place would never redraw.
- **iOS 16+**: the inline picker is backed by `UICalendarView`. Its selection delegate greys out rejected days, `DateBounds` map to the available date range, and the visible days are rebuilt after every change so it shows immediately rather than on the next scroll or tap.
- **iOS wheels, and inline below iOS 16**: `UIDatePicker` only supports min/max, so `DateBounds` stop the wheels natively and any other rejected pick snaps to the nearest selectable day.
- A selection the new rule rejects moves to the nearest selectable day on every platform. The state is the source of truth and the native view follows it.
- The saver re-attaches the rule and still restores lists saved before it existed. Year bounds use a dependency-free days-to-civil calculation.
- Docs rewritten with multiplatform examples. The sample shows an inline picker driven by a range chip row and a weekdays-only toggle, plus, on iOS only, a wheels picker to exercise the snapping fallback.

Two follow-up branches build on this one: `feat/compact-date-picker` and `feat/date-range-picker`.

## Test plan

- [x] `./gradlew :calf-ui:desktopTest` — 33 tests: `DateBoundsTest`, `DateBoundsSelectableDatesTest`, `AdaptiveDatePickerStateMaterialTest`, including Compose tests that re-sync the rule on recomposition and assert a weekend cell becomes disabled after switching to a weekdays-only rule
- [x] `./gradlew :calf-ui:testDebugUnitTest` — the shared tests on Android
- [x] calf-ui compiles for Android, iOS device and simulator, Desktop, JS and Wasm; the sample compiles on every target
- [x] iOS simulator: weekends greyed out with "Weekdays only", range chips hide the months outside the range, `UIKitDisplayMode.Wheels` snaps a rejected pick
- [x] Android: rule and range changes apply immediately without scrolling the calendar
