### PR TITLE
fix(navigation): keep each destination's saved state while it is on the back stack

### DIFF
--- a/calf-navigation/build.gradle.kts
+++ b/calf-navigation/build.gradle.kts
@@ -8,6 +8,15 @@ kotlin {
         implementation(libs.compose.material3)
     }
 
+    sourceSets.commonTest.dependencies {
+        implementation(libs.kotlin.test)
+    }
+
+    sourceSets.desktopTest.dependencies {
+        implementation(libs.compose.ui.test)
+        implementation(compose.desktop.currentOs)
+    }
+
     sourceSets.androidMain.dependencies {
         implementation(libs.android.navigation.compose)
     }

--- a/calf-navigation/src/commonMain/kotlin/com.mohamedrejeb.calf/navigation/AdaptiveNavHost.kt
+++ b/calf-navigation/src/commonMain/kotlin/com.mohamedrejeb.calf/navigation/AdaptiveNavHost.kt
@@ -3,7 +3,10 @@ package com.mohamedrejeb.calf.navigation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 
 @Composable
@@ -28,11 +31,34 @@ fun AdaptiveNavHost(
             navController.navigate(startDestination)
     }
 
+    // Keeps each destination's `rememberSaveable` state (list positions, form input) while the
+    // destination stays on the back stack, so coming back restores it.
+    val saveableStateHolder = rememberSaveableStateHolder()
+    ForgetPoppedDestinations(navController, saveableStateHolder)
+
     Box(modifier = modifier) {
         navController.currentDestination?.let { currentDestination ->
             graphBuilder.destinations.find { it.route == currentDestination }?.let { destination ->
-                destination.content(destination.arguments)
+                saveableStateHolder.SaveableStateProvider(key = currentDestination) {
+                    destination.content(destination.arguments)
+                }
             }
         }
+    }
+}
+
+/** Drops the saved state of destinations that left the back stack, so a later visit starts fresh. */
+@Composable
+private fun ForgetPoppedDestinations(
+    navController: AdaptiveNavHostController,
+    saveableStateHolder: SaveableStateHolder,
+) {
+    val routesOnStack = navController.backStack.toSet()
+    val retainedRoutes = remember { mutableSetOf<String>() }
+
+    SideEffect {
+        (retainedRoutes - routesOnStack).forEach(saveableStateHolder::removeState)
+        retainedRoutes.clear()
+        retainedRoutes.addAll(routesOnStack)
     }
 }

--- a/calf-navigation/src/desktopTest/kotlin/com/mohamedrejeb/calf/navigation/AdaptiveNavHostStateTest.kt
+++ b/calf-navigation/src/desktopTest/kotlin/com/mohamedrejeb/calf/navigation/AdaptiveNavHostStateTest.kt
@@ -1,0 +1,80 @@
+package com.mohamedrejeb.calf.navigation
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+
+private const val HOME = "home"
+private const val DETAIL = "detail"
+
+@OptIn(ExperimentalTestApi::class)
+class AdaptiveNavHostStateTest {
+
+
+    @Test
+    fun `saveable state of a destination survives navigating away and back`() = runComposeUiTest {
+        lateinit var navController: AdaptiveNavHostController
+        setContent {
+            navController = rememberNavController()
+            AdaptiveNavHost(navController = navController, startDestination = HOME) {
+                composable(HOME) { Counter(label = HOME) }
+                composable(DETAIL) { Text(DETAIL) }
+            }
+        }
+        waitForIdle()
+
+        onNodeWithText("$HOME 0").performClick()
+        onNodeWithText("$HOME 1").assertIsDisplayed()
+
+        navController.navigate(DETAIL)
+        waitForIdle()
+        onNodeWithText(DETAIL).assertIsDisplayed()
+
+        navController.popBackStack()
+        waitForIdle()
+
+        onNodeWithText("$HOME 1").assertIsDisplayed()
+    }
+
+    @Test
+    fun `saveable state of a popped destination is dropped`() = runComposeUiTest {
+        lateinit var navController: AdaptiveNavHostController
+        setContent {
+            navController = rememberNavController()
+            AdaptiveNavHost(navController = navController, startDestination = HOME) {
+                composable(HOME) { Text(HOME) }
+                composable(DETAIL) { Counter(label = DETAIL) }
+            }
+        }
+        waitForIdle()
+
+        navController.navigate(DETAIL)
+        waitForIdle()
+        onNodeWithText("$DETAIL 0").performClick()
+        onNodeWithText("$DETAIL 1").assertIsDisplayed()
+
+        navController.popBackStack()
+        waitForIdle()
+        navController.navigate(DETAIL)
+        waitForIdle()
+
+        onNodeWithText("$DETAIL 0").assertIsDisplayed()
+    }
+}
+
+@androidx.compose.runtime.Composable
+private fun Counter(label: String) {
+    var count by rememberSaveable { mutableStateOf(0) }
+    Button(onClick = { count++ }) {
+        Text("$label $count")
+    }
+}


### PR DESCRIPTION
AdaptiveNavHost rendered the current destination directly, so when the user navigated away the destination's rememberSaveable state (list positions, form input) was discarded, and coming back started from scratch. In the sample, opening any screen and going back reset the home list to the top.

Each destination is now composed inside a SaveableStateHolder keyed on its route, the way Jetpack's NavHost scopes its entries, and the saved state of routes that leave the back stack is dropped so a later visit starts fresh.