### PR TITLE
feat(ui): add AdaptiveCompactDatePicker

### DIFF
--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePicker.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePicker.kt
@@ -1,0 +1,49 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerColors
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerFormatter
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+
+/**
+ * A compact date picker that shows the selected date and opens the full picker on tap.
+ *
+ * On iOS this is the system compact `UIDatePicker`, which pops its calendar over the content.
+ * It applies bounds coming from a [DateBounds] natively, but cannot grey out days any other rule
+ * rejects: such a pick snaps to the nearest selectable day. On Material platforms it is an
+ * outlined button showing the formatted date that opens a `DatePickerDialog` holding a Material3
+ * `DatePicker`. Both share [state], including its selectable-dates rule.
+ *
+ * @param state the state that holds the selection and the selectable range.
+ * @param modifier the modifier applied to the field.
+ * @param enabled whether the user can open the picker.
+ * @param dateFormatter formats the date shown in the field and the dialog on Material platforms.
+ * @param colors colors of the picker; the selected day color tints the native iOS control.
+ * @param materialPlaceholder text shown in the field on Material platforms while nothing is
+ * selected; the iOS control always shows a date.
+ * @param materialConfirmText label of the dialog button that keeps the selection on Material platforms.
+ * @param materialDismissText label of the dialog button that discards the day picked in the
+ * dialog on Material platforms. Dismissing the dialog by tapping outside behaves the same way.
+ * The shared [state] only changes when the dialog is confirmed.
+ * @param materialTitle the dialog title slot on Material platforms. Unlike [AdaptiveDatePicker],
+ * `null` shows the Material3 default rather than hiding it, because a dialog needs a header.
+ * @param materialHeadline the dialog headline slot on Material platforms; `null` shows the
+ * Material3 default, which displays the day picked so far.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+expect fun AdaptiveCompactDatePicker(
+    state: AdaptiveDatePickerState,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    dateFormatter: DatePickerFormatter = remember { DatePickerDefaults.dateFormatter() },
+    colors: DatePickerColors = DatePickerDefaults.colors(),
+    materialPlaceholder: String = "Select date",
+    materialConfirmText: String = "OK",
+    materialDismissText: String = "Cancel",
+    materialTitle: (@Composable () -> Unit)? = null,
+    materialHeadline: (@Composable () -> Unit)? = null,
+)

--- a/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePickerMaterialTest.kt
+++ b/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePickerMaterialTest.kt
@@ -1,0 +1,123 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DisplayMode
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val PLACEHOLDER = "Pick a date"
+private const val CONFIRM = "Done"
+private const val DISMISS = "Back"
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
+class AdaptiveCompactDatePickerMaterialTest {
+
+    private val formatter = DatePickerDefaults.dateFormatter()
+
+    private fun state(selectedDateMillis: Long? = null) = AdaptiveDatePickerState(
+        initialSelectedDateMillis = selectedDateMillis,
+        initialDisplayedMonthMillis = selectedDateMillis,
+        yearRange = DatePickerDefaults.YearRange,
+        initialMaterialDisplayMode = DisplayMode.Picker,
+        initialUIKitDisplayMode = UIKitDisplayMode.Picker,
+    )
+
+    private fun fieldLabel(utcTimeMillis: Long): String =
+        requireNotNull(formatter.formatDate(utcTimeMillis, getCalendarLocalDefault()))
+
+    @Test
+    fun `shows the placeholder while nothing is selected`() = runComposeUiTest {
+        setContent {
+            AdaptiveCompactDatePicker(state = state(), materialPlaceholder = PLACEHOLDER)
+        }
+
+        onNodeWithText(PLACEHOLDER).assertIsDisplayed()
+    }
+
+    @Test
+    fun `shows the formatted selected date`() = runComposeUiTest {
+        setContent {
+            AdaptiveCompactDatePicker(state = state(MAR_15_2026), materialPlaceholder = PLACEHOLDER)
+        }
+
+        onNodeWithText(fieldLabel(MAR_15_2026)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the field opens a dialog with confirm and dismiss buttons`() = runComposeUiTest {
+        setContent {
+            AdaptiveCompactDatePicker(
+                state = state(),
+                materialPlaceholder = PLACEHOLDER,
+                materialConfirmText = CONFIRM,
+                materialDismissText = DISMISS,
+            )
+        }
+
+        onNodeWithText(PLACEHOLDER).performClick()
+
+        onNodeWithText(CONFIRM).assertIsDisplayed()
+        onNodeWithText(DISMISS).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a day picked in the dialog does not reach the state until confirmed`() = runComposeUiTest {
+        val state = state(MAR_15_2026)
+        setContent {
+            AdaptiveCompactDatePicker(state = state, materialConfirmText = CONFIRM, materialDismissText = DISMISS)
+        }
+
+        onNodeWithText(fieldLabel(MAR_15_2026)).performClick()
+        dayCell(MAR_16_2026).performClick()
+
+        assertEquals(MAR_15_2026, state.selectedDateMillis)
+    }
+
+    @Test
+    fun `confirming applies the day picked in the dialog`() = runComposeUiTest {
+        val state = state(MAR_15_2026)
+        setContent {
+            AdaptiveCompactDatePicker(state = state, materialConfirmText = CONFIRM, materialDismissText = DISMISS)
+        }
+
+        onNodeWithText(fieldLabel(MAR_15_2026)).performClick()
+        dayCell(MAR_16_2026).performClick()
+        onNodeWithText(CONFIRM).performClick()
+
+        assertEquals(MAR_16_2026, state.selectedDateMillis)
+        onAllNodesWithText(CONFIRM).assertCountEquals(0)
+    }
+
+    @Test
+    fun `dismissing discards the day picked in the dialog`() = runComposeUiTest {
+        val state = state(MAR_15_2026)
+        setContent {
+            AdaptiveCompactDatePicker(state = state, materialConfirmText = CONFIRM, materialDismissText = DISMISS)
+        }
+
+        onNodeWithText(fieldLabel(MAR_15_2026)).performClick()
+        dayCell(MAR_16_2026).performClick()
+        onNodeWithText(DISMISS).performClick()
+
+        assertEquals(MAR_15_2026, state.selectedDateMillis)
+        onAllNodesWithText(DISMISS).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a disabled field cannot be opened`() = runComposeUiTest {
+        setContent {
+            AdaptiveCompactDatePicker(state = state(), enabled = false, materialPlaceholder = PLACEHOLDER)
+        }
+
+        onNodeWithText(PLACEHOLDER).assertIsNotEnabled()
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePicker.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePicker.ios.kt
@@ -1,0 +1,53 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.DatePickerColors
+import androidx.compose.material3.DatePickerFormatter
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
+import androidx.compose.ui.viewinterop.UIKitInteropProperties
+import androidx.compose.ui.viewinterop.UIKitView
+import com.mohamedrejeb.calf.core.InternalCalfApi
+
+@OptIn(ExperimentalMaterial3Api::class, InternalCalfApi::class, ExperimentalComposeUiApi::class)
+@Composable
+actual fun AdaptiveCompactDatePicker(
+    state: AdaptiveDatePickerState,
+    modifier: Modifier,
+    enabled: Boolean,
+    dateFormatter: DatePickerFormatter,
+    colors: DatePickerColors,
+    materialPlaceholder: String,
+    materialConfirmText: String,
+    materialDismissText: String,
+    materialTitle: (@Composable () -> Unit)?,
+    materialHeadline: (@Composable () -> Unit)?,
+) {
+    val datePickerManager = rememberDatePickerManager(
+        state = state,
+        presentation = IosDatePickerPresentation.Compact,
+    )
+
+    SyncNativeDatePicker(
+        state = state,
+        manager = datePickerManager,
+        colors = colors,
+        enabled = enabled,
+    )
+
+    key(datePickerManager) {
+        UIKitView(
+            factory = {
+                datePickerManager.view
+            },
+            properties = UIKitInteropProperties(
+                interactionMode = UIKitInteropInteractionMode.NonCooperative,
+            ),
+            modifier = modifier.size(datePickerManager.viewSize),
+        )
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePicker.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDatePicker.ios.kt
@@ -10,20 +10,22 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalAbsoluteTonalElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
-import androidx.compose.ui.platform.LocalLayoutDirection
 import com.mohamedrejeb.calf.core.InternalCalfApi
 import com.mohamedrejeb.calf.ui.utils.applyLayoutDirection
 import com.mohamedrejeb.calf.ui.utils.surfaceColorAtElevation
 import kotlinx.cinterop.ExperimentalForeignApi
 
-@OptIn(ExperimentalForeignApi::class, ExperimentalMaterial3Api::class, InternalCalfApi::class,
-    ExperimentalComposeUiApi::class
+@OptIn(
+    ExperimentalForeignApi::class, ExperimentalMaterial3Api::class, InternalCalfApi::class,
+    ExperimentalComposeUiApi::class,
 )
 @Composable
 actual fun AdaptiveDatePicker(
@@ -35,87 +37,111 @@ actual fun AdaptiveDatePicker(
     showModeToggle: Boolean,
     colors: DatePickerColors
 ) {
-    val datePickerManager = remember {
-        DatePickerManager(
-            initialSelectedDateMillis = state.selectedDateMillis,
-            displayMode = state.initialUIKitDisplayMode,
-            onSelectionChanged = { dateMillis ->
-                state.selectedDateMillis = dateMillis
-            },
-            isDaySelectable = { dateMillis ->
-                state.isDaySelectable(dateMillis)
-            },
-            resolveSelection = { pickedMillis ->
-                if (state.isDaySelectable(pickedMillis)) {
-                    pickedMillis
-                } else {
-                    val bounds = state.dateBounds
-                    nearestSelectableDay(
-                        utcTimeMillis = pickedMillis,
-                        minDateMillis = bounds.minDateMillis,
-                        maxDateMillis = bounds.maxDateMillis,
-                        selectableDates = state.selectableDates,
-                    ) ?: pickedMillis
-                }
-            },
-        )
-    }
+    val datePickerManager = rememberDatePickerManager(
+        state = state,
+        presentation = when (state.initialUIKitDisplayMode) {
+            UIKitDisplayMode.Picker -> IosDatePickerPresentation.Inline
+            else -> IosDatePickerPresentation.Wheels
+        },
+    )
 
-    val layoutDirection = LocalLayoutDirection.current
-
-    val absoluteElevation = LocalAbsoluteTonalElevation.current
-
-    val containerColorAtElevation =
-        surfaceColorAtElevation(
-            color = colors.containerColor,
-            elevation = absoluteElevation
-        )
-
-    LaunchedEffect(layoutDirection) {
-        datePickerManager.view.applyLayoutDirection(layoutDirection)
-    }
-
-    LaunchedEffect(state.selectableDates) {
-        val bounds = state.dateBounds
-        datePickerManager.applyDateBounds(
-            minDateMillis = bounds.minDateMillis,
-            maxDateMillis = bounds.maxDateMillis,
-        )
-        datePickerManager.updateSelectableDates()
-    }
-
-    LaunchedEffect(state.selectedDateMillis) {
-        datePickerManager.setSelectedDate(state.selectedDateMillis)
-    }
-
-    LaunchedEffect(colors, containerColorAtElevation) {
-        datePickerManager.applyColors(
-            containerColor = containerColorAtElevation,
-            dayContentColor = colors.dayContentColor,
-            selectedDayContainerColor = colors.selectedDayContainerColor,
-        )
-    }
+    SyncNativeDatePicker(
+        state = state,
+        manager = datePickerManager,
+        colors = colors,
+        enabled = true,
+    )
 
     Box(
         modifier = modifier
     ) {
-        UIKitView(
-            factory = {
-                datePickerManager.view
-            },
-            properties = UIKitInteropProperties(
-                interactionMode = UIKitInteropInteractionMode.NonCooperative,
-            ),
-            modifier = Modifier
-                .background(colors.containerColor)
-                .fillMaxWidth()
-                .then(
-                    if (datePickerManager.aspectRatio.isFinite() && datePickerManager.aspectRatio > 0f)
-                        Modifier
-                            .aspectRatio(datePickerManager.aspectRatio)
-                    else
-                        Modifier
-                )
+        key(datePickerManager) {
+            UIKitView(
+                factory = {
+                    datePickerManager.view
+                },
+                properties = UIKitInteropProperties(
+                    interactionMode = UIKitInteropInteractionMode.NonCooperative,
+                ),
+                modifier = Modifier
+                    .background(colors.containerColor)
+                    .fillMaxWidth()
+                    .then(
+                        if (datePickerManager.aspectRatio.isFinite() && datePickerManager.aspectRatio > 0f)
+                            Modifier
+                                .aspectRatio(datePickerManager.aspectRatio)
+                        else
+                            Modifier
+                    )
+            )
+        }
+    }
+}
+
+/** Creates the native picker for [state] and recreates it if a different state is passed. */
+@OptIn(ExperimentalMaterial3Api::class, InternalCalfApi::class)
+@Composable
+internal fun rememberDatePickerManager(
+    state: AdaptiveDatePickerState,
+    presentation: IosDatePickerPresentation,
+): DatePickerManager = remember(state) {
+    DatePickerManager(
+        initialSelectedDateMillis = state.selectedDateMillis,
+        presentation = presentation,
+        onSelectionChanged = { dateMillis ->
+            state.selectedDateMillis = dateMillis
+        },
+        isDaySelectable = { dateMillis ->
+            state.isDaySelectable(dateMillis)
+        },
+        resolveSelection = { pickedMillis ->
+            resolvePickedDay(pickedMillis, state.dateBounds, state.selectableDates)
+        },
+    )
+}
+
+/** Pushes [state], colors, layout direction and the enabled flag into the native picker. */
+@OptIn(ExperimentalMaterial3Api::class, InternalCalfApi::class)
+@Composable
+internal fun SyncNativeDatePicker(
+    state: AdaptiveDatePickerState,
+    manager: DatePickerManager,
+    colors: DatePickerColors,
+    enabled: Boolean,
+) {
+    val layoutDirection = LocalLayoutDirection.current
+    val absoluteElevation = LocalAbsoluteTonalElevation.current
+    val containerColorAtElevation = surfaceColorAtElevation(
+        color = colors.containerColor,
+        elevation = absoluteElevation,
+    )
+
+    LaunchedEffect(layoutDirection) {
+        manager.view.applyLayoutDirection(layoutDirection)
+    }
+
+    LaunchedEffect(state.selectableDates) {
+        val bounds = state.dateBounds
+        manager.applyDateBounds(
+            minDateMillis = bounds.minDateMillis,
+            maxDateMillis = bounds.maxDateMillis,
+        )
+        manager.updateSelectableDates()
+    }
+
+    LaunchedEffect(state.selectedDateMillis) {
+        manager.setSelectedDate(state.selectedDateMillis)
+    }
+
+    LaunchedEffect(enabled) {
+        manager.setEnabled(enabled)
+    }
+
+    LaunchedEffect(colors, containerColorAtElevation) {
+        manager.applyColors(
+            containerColor = containerColorAtElevation,
+            dayContentColor = colors.dayContentColor,
+            selectedDayContainerColor = colors.selectedDayContainerColor,
         )
     }
 }

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarDatePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarDatePickerBackend.kt
@@ -108,6 +108,10 @@ internal class CalendarDatePickerBackend(
         refresh()
     }
 
+    override fun setEnabled(enabled: Boolean) {
+        calendarView.userInteractionEnabled = enabled
+    }
+
     /**
      * Rebuilds the days around the visible month, so bounds and rule changes show right away
      * instead of on the next scroll or tap.

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DatePickerManager.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DatePickerManager.kt
@@ -4,10 +4,12 @@ package com.mohamedrejeb.calf.ui.datepicker
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import com.mohamedrejeb.calf.core.InternalCalfApi
-import com.mohamedrejeb.calf.ui.utils.applyTheme
 import com.mohamedrejeb.calf.ui.utils.isDark
 import com.mohamedrejeb.calf.ui.utils.isIOSVersionAtLeast
 import com.mohamedrejeb.calf.ui.utils.toUIColor
@@ -18,38 +20,53 @@ import platform.UIKit.UIDatePickerMode
 import platform.UIKit.UIDatePickerStyle
 import platform.UIKit.UIView
 
-private const val FIRST_IOS_WITH_CALENDAR_VIEW = 16
+internal const val FIRST_IOS_WITH_CALENDAR_VIEW = 16
+
+/** How the native date picker is presented. */
+internal enum class IosDatePickerPresentation {
+    /** A full calendar; `UICalendarView` on iOS 16+, an inline `UIDatePicker` before that. */
+    Inline,
+
+    /** Spinning wheels. */
+    Wheels,
+
+    /** A small button showing the date that pops the calendar over the content. */
+    Compact,
+}
 
 /**
- * Owns the native date picker view and keeps it in sync with [AdaptiveDatePickerState].
+ * Owns the native date picker view and keeps it in sync with the selection it is given.
  *
- * The inline style uses `UICalendarView` on iOS 16+, which can grey out days the
- * [isDaySelectable] rule rejects. The wheels style, and the inline style on older systems,
- * use `UIDatePicker` and resolve rejected picks through [resolveSelection].
+ * The inline presentation uses `UICalendarView` on iOS 16+, which greys out days the
+ * [isDaySelectable] rule rejects. Every other presentation, including the system compact
+ * control, uses `UIDatePicker`, which only enforces bounds, and resolves rejected picks
+ * through [resolveSelection].
  */
 @InternalCalfApi
 class DatePickerManager internal constructor(
     initialSelectedDateMillis: Long?,
-    displayMode: UIKitDisplayMode,
+    private val presentation: IosDatePickerPresentation,
     onSelectionChanged: (utcTimeMillis: Long?) -> Unit,
     isDaySelectable: (utcTimeMillis: Long) -> Boolean,
     resolveSelection: (pickedUtcTimeMillis: Long) -> Long,
 ) {
+    private val onNativeSelectionChanged: (Long?) -> Unit = { utcTimeMillis ->
+        remeasureCompactView()
+        onSelectionChanged(utcTimeMillis)
+    }
+
     private val backend: IosDatePickerBackend =
-        if (displayMode == UIKitDisplayMode.Picker && isIOSVersionAtLeast(FIRST_IOS_WITH_CALENDAR_VIEW)) {
+        if (presentation == IosDatePickerPresentation.Inline && isIOSVersionAtLeast(FIRST_IOS_WITH_CALENDAR_VIEW)) {
             CalendarDatePickerBackend(
                 initialSelectedDateMillis = initialSelectedDateMillis,
-                onSelectionChanged = onSelectionChanged,
+                onSelectionChanged = onNativeSelectionChanged,
                 isDaySelectable = isDaySelectable,
             )
         } else {
-            WheelsDatePickerBackend(
+            UIDatePickerBackend(
                 initialSelectedDateMillis = initialSelectedDateMillis,
-                style = when (displayMode) {
-                    UIKitDisplayMode.Picker -> UIDatePickerStyle.UIDatePickerStyleInline
-                    else -> UIDatePickerStyle.UIDatePickerStyleWheels
-                },
-                onSelectionChanged = onSelectionChanged,
+                style = presentation.toUIDatePickerStyle(),
+                onSelectionChanged = onNativeSelectionChanged,
                 resolveSelection = resolveSelection,
             )
         }
@@ -60,6 +77,13 @@ class DatePickerManager internal constructor(
 
     /** Width divided by height of the native view, or 0 when it has no intrinsic size yet. */
     internal var aspectRatio by mutableFloatStateOf(0f)
+        private set
+
+    /**
+     * Intrinsic size of the native view in points, which equal dp on iOS. The compact picker
+     * resizes with its date label, so it is measured again after every selection change.
+     */
+    internal var viewSize: DpSize by mutableStateOf(backend.view.currentSize())
         private set
 
     init {
@@ -81,7 +105,7 @@ class DatePickerManager internal constructor(
     }
 
     internal fun applyTheme(isDark: Boolean) {
-        backend.view.applyTheme(isDark)
+        backend.applyTheme(isDark)
     }
 
     internal fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?) {
@@ -95,16 +119,37 @@ class DatePickerManager internal constructor(
 
     internal fun setSelectedDate(utcTimeMillis: Long?) {
         backend.setSelectedDate(utcTimeMillis)
+        remeasureCompactView()
+    }
+
+    private fun remeasureCompactView() {
+        if (presentation != IosDatePickerPresentation.Compact) return
+        backend.view.sizeToFit()
+        viewSize = backend.view.currentSize()
+    }
+
+    internal fun setEnabled(enabled: Boolean) {
+        backend.setEnabled(enabled)
     }
 }
 
-private fun UIView.aspectRatioOrZero(): Float =
+private fun IosDatePickerPresentation.toUIDatePickerStyle(): UIDatePickerStyle =
+    when (this) {
+        IosDatePickerPresentation.Inline -> UIDatePickerStyle.UIDatePickerStyleInline
+        IosDatePickerPresentation.Wheels -> UIDatePickerStyle.UIDatePickerStyleWheels
+        IosDatePickerPresentation.Compact -> UIDatePickerStyle.UIDatePickerStyleCompact
+    }
+
+private fun UIView.currentSize(): DpSize =
+    frame.useContents { DpSize(size.width.dp, size.height.dp) }
+
+internal fun UIView.aspectRatioOrZero(): Float =
     frame.useContents {
         if (size.height > 0.0) (size.width / size.height).toFloat() else 0f
     }
 
 /** Size of a stock inline `UIDatePicker`, used when the calendar view reports no size yet. */
-private fun inlineDatePickerAspectRatio(): Float =
+internal fun inlineDatePickerAspectRatio(): Float =
     UIDatePicker().apply {
         datePickerMode = UIDatePickerMode.UIDatePickerModeDate
         preferredDatePickerStyle = UIDatePickerStyle.UIDatePickerStyleInline

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/IosDatePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/IosDatePickerBackend.kt
@@ -1,5 +1,6 @@
 package com.mohamedrejeb.calf.ui.datepicker
 
+import com.mohamedrejeb.calf.ui.utils.applyTheme
 import platform.UIKit.UIColor
 import platform.UIKit.UIView
 
@@ -19,5 +20,11 @@ internal interface IosDatePickerBackend {
     /** Re-evaluates which days can be picked after the rule or the bounds changed. */
     fun updateSelectableDates()
 
+    fun setEnabled(enabled: Boolean)
+
     fun applyColors(containerColor: UIColor, selectedDayContainerColor: UIColor)
+
+    fun applyTheme(isDark: Boolean) {
+        view.applyTheme(isDark)
+    }
 }

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/UIDatePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/UIDatePickerBackend.kt
@@ -18,11 +18,11 @@ import platform.darwin.NSObject
 import platform.objc.sel_registerName
 
 /**
- * Picker backed by `UIDatePicker`, used for the wheels style and as the inline fallback below
+ * Picker backed by `UIDatePicker`: the wheels and compact styles, and the inline fallback below
  * iOS 16. `UIDatePicker` can only enforce a minimum and a maximum date, so a picked day the
- * rule rejects is replaced by [resolveSelection] and the wheels move to that day.
+ * rule rejects is replaced by [resolveSelection] and the control moves to that day.
  */
-internal class WheelsDatePickerBackend(
+internal class UIDatePickerBackend(
     initialSelectedDateMillis: Long?,
     style: UIDatePickerStyle,
     private val onSelectionChanged: (utcTimeMillis: Long?) -> Unit,
@@ -53,6 +53,7 @@ internal class WheelsDatePickerBackend(
         datePicker.timeZone = TimeZone.currentSystemDefault().toNSTimeZone()
         datePicker.datePickerMode = UIDatePickerMode.UIDatePickerModeDate
         datePicker.preferredDatePickerStyle = style
+        datePicker.sizeToFit()
         datePicker.addTarget(
             target = valueChangedTarget,
             action = sel_registerName("onDateChanged:"),
@@ -74,6 +75,10 @@ internal class WheelsDatePickerBackend(
 
     override fun updateSelectableDates() {
         // UIDatePicker cannot grey out individual days; rejected picks are resolved on change.
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        datePicker.enabled = enabled
     }
 
     override fun applyColors(containerColor: UIColor, selectedDayContainerColor: UIColor) {

--- a/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePicker.material.kt
+++ b/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveCompactDatePicker.material.kt
@@ -1,0 +1,109 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerColors
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DatePickerFormatter
+import androidx.compose.material3.DatePickerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+actual fun AdaptiveCompactDatePicker(
+    state: AdaptiveDatePickerState,
+    modifier: Modifier,
+    enabled: Boolean,
+    dateFormatter: DatePickerFormatter,
+    colors: DatePickerColors,
+    materialPlaceholder: String,
+    materialConfirmText: String,
+    materialDismissText: String,
+    materialTitle: (@Composable () -> Unit)?,
+    materialHeadline: (@Composable () -> Unit)?,
+) {
+    var isDialogOpen by rememberSaveable { mutableStateOf(false) }
+
+    val label = state.selectedDateMillis
+        ?.let { dateFormatter.formatDate(it, getCalendarLocalDefault()) }
+        ?: materialPlaceholder
+
+    OutlinedButton(
+        onClick = { isDialogOpen = true },
+        enabled = enabled,
+        modifier = modifier,
+    ) {
+        Text(label)
+    }
+
+    if (!isDialogOpen) return
+
+    // The dialog edits a scratch copy so the shared state only changes on confirm.
+    // It leaves composition when the dialog closes, so every opening starts fresh.
+    val dialogState = remember { state.newDialogState() }
+
+    val keepSelection = {
+        state.selectedDateMillis = dialogState.selectedDateMillis
+        isDialogOpen = false
+    }
+    val discardSelection = { isDialogOpen = false }
+
+    DatePickerDialog(
+        onDismissRequest = discardSelection,
+        confirmButton = {
+            TextButton(onClick = keepSelection) {
+                Text(materialConfirmText)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = discardSelection) {
+                Text(materialDismissText)
+            }
+        },
+        colors = colors,
+    ) {
+        DatePicker(
+            state = dialogState,
+            dateFormatter = dateFormatter,
+            title = materialTitle ?: {
+                DatePickerDefaults.DatePickerTitle(
+                    displayMode = dialogState.displayMode,
+                    modifier = Modifier.padding(DatePickerTitlePadding),
+                )
+            },
+            headline = materialHeadline ?: {
+                DatePickerDefaults.DatePickerHeadline(
+                    selectedDateMillis = dialogState.selectedDateMillis,
+                    displayMode = dialogState.displayMode,
+                    dateFormatter = dateFormatter,
+                    modifier = Modifier.padding(DatePickerHeadlinePadding),
+                )
+            },
+            colors = colors,
+        )
+    }
+}
+
+/** A Material3 state seeded from this state that keeps following its rule. */
+@OptIn(ExperimentalMaterial3Api::class)
+private fun AdaptiveDatePickerState.newDialogState(): DatePickerState {
+    val scratch = DatePickerState(
+        locale = getCalendarLocalDefault(),
+        initialSelectedDateMillis = selectedDateMillis,
+        initialDisplayedMonthMillis = selectedDateMillis,
+        yearRange = yearRange,
+        initialDisplayMode = displayMode,
+    )
+    return RuleTrackingDatePickerState(scratch) { selectableDates }
+}

--- a/docs/ui/adaptive-date-picker.md
+++ b/docs/ui/adaptive-date-picker.md
@@ -1,6 +1,11 @@
 # Date Picker
 
-`AdaptiveDatePicker` is a date picker that adapts to the platform it is running on. It is a wrapper around the Material3 `DatePicker` on Android, Desktop and Web, and around `UICalendarView` (iOS 16+) or `UIDatePicker` on iOS, providing a native date selection experience on each platform.
+Calf provides two date pickers that adapt to the platform they run on:
+
+1. **AdaptiveDatePicker**: the full calendar, always visible. Material3 `DatePicker` on Android, Desktop and Web; `UICalendarView` (iOS 16+) or `UIDatePicker` on iOS.
+2. **AdaptiveCompactDatePicker**: a field showing the selected date that opens the calendar on tap. A `DatePickerDialog` on Material platforms; the system compact `UIDatePicker` on iOS.
+
+Both share `AdaptiveDatePickerState` and support the same [selectable rules](#restricting-selectable-dates).
 
 ## Usage
 
@@ -91,8 +96,30 @@ Pass a stable instance, such as an `object`, a data class or a remembered value,
 |---|---|
 | Material (Android, Desktop, Web) | Rejected days are disabled in the calendar grid. `isSelectableYear` disables years in the year picker. |
 | iOS 16+ inline calendar (`UIKitDisplayMode.Picker`) | Backed by `UICalendarView`: rejected days are greyed out and cannot be tapped. Bounds coming from a `DateBounds` also hide the months outside the range. |
-| iOS wheels (`UIKitDisplayMode.Wheels`) and inline below iOS 16 | Backed by `UIDatePicker`, which cannot grey out days. Bounds coming from a `DateBounds` stop the wheels at the range; picking any other rejected day snaps the wheels to the nearest selectable day. |
+| iOS compact picker, wheels (`UIKitDisplayMode.Wheels`) and inline below iOS 16 | Backed by `UIDatePicker`, which cannot grey out days. Bounds coming from a `DateBounds` apply natively; picking any other rejected day snaps the control to the nearest selectable day. |
 
 On every platform, a current selection that a new rule rejects is moved to the nearest selectable day. `isSelectableYear` has no effect on iOS.
+
+## Compact picker
+
+`AdaptiveCompactDatePicker` takes the same state as `AdaptiveDatePicker`, so the bounds and rules apply unchanged. It is the right choice for forms and for anything that should not take the full height of a calendar.
+
+```kotlin
+val state = rememberAdaptiveDatePickerState()
+
+AdaptiveCompactDatePicker(
+    state = state,
+    enabled = true,
+    // Material only: the field placeholder and the dialog buttons.
+    materialPlaceholder = "Select date",
+    materialConfirmText = "OK",
+    materialDismissText = "Cancel",
+)
+```
+
+| Platform | Behaviour |
+|---|---|
+| Material (Android, Desktop, Web) | An outlined button with the formatted date opens a `DatePickerDialog`. The day picked in the dialog reaches the state only on confirm; dismiss, or tapping outside, discards it. |
+| iOS | The system compact `UIDatePicker`, which pops its calendar over the content. Changes apply immediately, as they do everywhere in iOS. Bounds coming from a `DateBounds` apply natively; the control cannot grey out days any other rule rejects, so such a pick snaps to the nearest selectable day. |
 
 > `AdaptiveDatePicker` has no `dateValidator` parameter. An earlier version of this page documented one that never existed. Use `selectableDates` with `DateBounds` as described above instead.

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/Screen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/Screen.kt
@@ -99,7 +99,7 @@ enum class Screen(
     ),
     DatePicker(
         title = "Adaptive Date Picker",
-        description = "Date selection with native iOS UIDatePicker and Material3 DatePicker",
+        description = "Inline and compact date pickers with the native iOS calendar and Material3",
         icon = Icons.Outlined.CalendarMonth,
         category = ScreenCategory.Pickers,
     ),

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/DatePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/DatePickerScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mohamedrejeb.calf.sample.components.SampleScreenScaffold
 import com.mohamedrejeb.calf.sample.currentPlatform
+import com.mohamedrejeb.calf.ui.datepicker.AdaptiveCompactDatePicker
 import com.mohamedrejeb.calf.ui.datepicker.AdaptiveDatePicker
 import com.mohamedrejeb.calf.ui.datepicker.DateBounds
 import com.mohamedrejeb.calf.ui.datepicker.UIKitDisplayMode
@@ -93,6 +94,7 @@ fun DatePickerScreen(
     }
 
     val inlineState = rememberAdaptiveDatePickerState(selectableDates = selectableDates)
+    val compactState = rememberAdaptiveDatePickerState(selectableDates = selectableDates)
     val wheelsState = rememberAdaptiveDatePickerState(
         initialUIKitDisplayMode = UIKitDisplayMode.Wheels,
         selectableDates = selectableDates,
@@ -110,8 +112,8 @@ fun DatePickerScreen(
                 .padding(16.dp)
         ) {
             Text(
-                text = "Date selection using the native iOS controls and the Material3 DatePicker. " +
-                    "The controls below restrict which days can be picked on both platforms.",
+                text = "Inline and compact date pickers backed by the native iOS controls " +
+                    "and the Material3 pickers. The controls below restrict every picker on this screen.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -152,6 +154,28 @@ fun DatePickerScreen(
                 AdaptiveSwitch(
                     checked = weekdaysOnly,
                     onCheckedChange = { weekdaysOnly = it },
+                )
+            }
+
+            SectionDivider()
+
+            SectionTitle(
+                title = "Compact picker",
+                description = "A field that opens the calendar on tap.",
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Selected: ${compactState.selectedDateMillis.toDateLabel()}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f),
+                )
+                AdaptiveCompactDatePicker(
+                    state = compactState,
+                    colors = sampleDatePickerColors(),
                 )
             }
 


### PR DESCRIPTION
A field showing the selected date that opens the calendar on tap, sharing AdaptiveDatePickerState with the inline picker so the selectable-dates rule applies unchanged.

- Material: an outlined button opens a DatePickerDialog that edits a scratch state, so the shared state only changes on confirm; dismiss or tapping outside discards the pick
- iOS: the system compact UIDatePicker, which pops its calendar over the content. Bounds coming from a DateBounds apply natively; the control cannot grey out days any other rule rejects, so such a pick snaps to the nearest selectable day
- iOS: DatePickerManager gains presentations (inline, wheels, compact), an enabled flag and an intrinsic size that is measured again after each selection because the compact label resizes
- iOS: the state-to-native sync composable is shared by the inline and compact pickers, and native pickers are keyed on their state so taps never reach a stale instance
- Tests: AdaptiveCompactDatePickerMaterialTest (desktopTest, Compose UI, incl. picking a day in the dialog)
- Docs: compact picker section; sample gains a compact section