### PR TITLE
feat(ui): add AdaptiveDateRangePicker

### DIFF
--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePicker.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePicker.kt
@@ -1,0 +1,109 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.DatePickerColors
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerFormatter
+import androidx.compose.material3.DateRangePicker
+import androidx.compose.material3.DateRangePickerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A date range picker that adapts to the platform it is running on.
+ *
+ * On Material platforms it is the Material3 `DateRangePicker`. On iOS 16+ it is a native
+ * `UICalendarView`: the first tap picks the start, a tap on or after it picks the end, a tap
+ * before it moves the start, and any tap on a completed range starts a new one. Below iOS 16
+ * the Material3 picker is shown.
+ *
+ * @param state the state that holds the selected range and the selectable dates.
+ * @param modifier the modifier applied to the picker.
+ * @param dateFormatter formats dates on Material platforms.
+ * @param title the title slot on Material platforms; hidden when `null`.
+ * @param headline the headline slot on Material platforms; hidden when `null`.
+ * @param showModeToggle whether Material platforms offer the text input mode.
+ * @param colors colors of the picker; the selected day color tints the native iOS calendar.
+ *
+ * On Material platforms the picker scrolls through months, so it needs a bounded height. When
+ * the parent gives none, for example inside a vertically scrolling column, it falls back to
+ * [DateRangePickerFallbackHeight]; pass a `height` modifier to choose your own.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+expect fun AdaptiveDateRangePicker(
+    state: AdaptiveDateRangePickerState,
+    modifier: Modifier = Modifier,
+    dateFormatter: DatePickerFormatter = remember { DatePickerDefaults.dateFormatter() },
+    title: (@Composable () -> Unit)? = null,
+    headline: (@Composable () -> Unit)? = null,
+    showModeToggle: Boolean = true,
+    colors: DatePickerColors = DatePickerDefaults.colors(),
+)
+
+/** Height of the Material range picker when its parent gives no vertical bound. */
+val DateRangePickerFallbackHeight: Dp = 568.dp
+
+/** Paddings of the Material3 range picker defaults, which Material3 keeps private. */
+internal val DateRangePickerTitlePadding = PaddingValues(start = 64.dp, end = 12.dp)
+internal val DateRangePickerHeadlinePadding = PaddingValues(start = 64.dp, end = 12.dp, bottom = 12.dp)
+
+/** The Material3 range picker bound to [state]; shared by Material platforms and the iOS fallback. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun MaterialDateRangePicker(
+    state: AdaptiveDateRangePickerState,
+    modifier: Modifier,
+    dateFormatter: DatePickerFormatter,
+    title: (@Composable () -> Unit)?,
+    headline: (@Composable () -> Unit)?,
+    showModeToggle: Boolean,
+    colors: DatePickerColors,
+) {
+    BoundedMaterial3DateRangePicker(
+        state = state.dateRangePickerState,
+        modifier = modifier,
+        dateFormatter = dateFormatter,
+        title = title,
+        headline = headline,
+        showModeToggle = showModeToggle,
+        colors = colors,
+    )
+}
+
+/** A Material3 range picker that falls back to [DateRangePickerFallbackHeight] under an unbounded height. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun BoundedMaterial3DateRangePicker(
+    state: DateRangePickerState,
+    modifier: Modifier,
+    dateFormatter: DatePickerFormatter,
+    title: (@Composable () -> Unit)?,
+    headline: (@Composable () -> Unit)?,
+    showModeToggle: Boolean,
+    colors: DatePickerColors,
+) {
+    // Material3's DateRangePicker scrolls its months and throws under an unbounded height.
+    BoxWithConstraints(modifier = modifier) {
+        val boundedHeight = if (maxHeight == Dp.Infinity) {
+            Modifier.height(DateRangePickerFallbackHeight)
+        } else {
+            Modifier
+        }
+        DateRangePicker(
+            state = state,
+            modifier = boundedHeight,
+            dateFormatter = dateFormatter,
+            colors = colors,
+            title = title,
+            headline = headline,
+            showModeToggle = showModeToggle,
+        )
+    }
+}

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePickerState.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePickerState.kt
@@ -1,0 +1,178 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DateRangePickerState
+import androidx.compose.material3.DisplayMode
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+
+/**
+ * Creates and remembers an [AdaptiveDateRangePickerState].
+ *
+ * @param initialSelectedStartDateMillis timestamp in _UTC_ milliseconds from the epoch of the
+ * initial start date, or `null` for no selection.
+ * @param initialSelectedEndDateMillis timestamp in _UTC_ milliseconds from the epoch of the
+ * initial end date, or `null` for no end date. Requires a start date.
+ * @param initialDisplayedMonthMillis timestamp in _UTC_ milliseconds from the epoch of the month
+ * to display first; the current month when `null`.
+ * @param yearRange the years the picker is limited to.
+ * @param initialMaterialDisplayMode the initial [DisplayMode] on Material platforms.
+ * @param selectableDates the rule deciding which days can be picked, see
+ * [AdaptiveDateRangePickerState.selectableDates]. Use [DateBounds] for a minimum and maximum
+ * day and [and] to combine rules. Pass a stable instance.
+ */
+@Composable
+@ExperimentalMaterial3Api
+fun rememberAdaptiveDateRangePickerState(
+    initialSelectedStartDateMillis: Long? = null,
+    initialSelectedEndDateMillis: Long? = null,
+    initialDisplayedMonthMillis: Long? = initialSelectedStartDateMillis,
+    yearRange: IntRange = DatePickerDefaults.YearRange,
+    initialMaterialDisplayMode: DisplayMode = DisplayMode.Picker,
+    selectableDates: SelectableDates = DatePickerDefaults.AllDates,
+): AdaptiveDateRangePickerState =
+    rememberSaveable(
+        saver = AdaptiveDateRangePickerState.Saver(selectableDates),
+    ) {
+        AdaptiveDateRangePickerState(
+            initialSelectedStartDateMillis = initialSelectedStartDateMillis,
+            initialSelectedEndDateMillis = initialSelectedEndDateMillis,
+            initialDisplayedMonthMillis = initialDisplayedMonthMillis,
+            yearRange = yearRange,
+            initialMaterialDisplayMode = initialMaterialDisplayMode,
+            selectableDates = selectableDates,
+        )
+    }.apply {
+        // Keep the rule in sync when the caller passes a new one on recomposition.
+        this.selectableDates = selectableDates
+    }
+
+/**
+ * State of an [AdaptiveDateRangePicker]: the selected start and end days plus the selectable
+ * range. It wraps a Material3 [DateRangePickerState] on every platform.
+ *
+ * Unlike [AdaptiveDatePickerState], a range is not adjusted automatically when the rule
+ * changes; it is validated when set, see [setSelection].
+ *
+ * @param initialSelectedStartDateMillis see [rememberAdaptiveDateRangePickerState].
+ * @param initialSelectedEndDateMillis see [rememberAdaptiveDateRangePickerState].
+ * @param initialDisplayedMonthMillis see [rememberAdaptiveDateRangePickerState].
+ * @param yearRange the years the picker is limited to.
+ * @param initialMaterialDisplayMode the initial [DisplayMode] on Material platforms.
+ * @param selectableDates initial value of [selectableDates].
+ * Initial dates are validated like [setSelection]: a missing or out-of-range start leaves the
+ * selection empty, and an end before the start does too.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Stable
+class AdaptiveDateRangePickerState(
+    initialSelectedStartDateMillis: Long?,
+    initialSelectedEndDateMillis: Long?,
+    initialDisplayedMonthMillis: Long?,
+    val yearRange: IntRange,
+    initialMaterialDisplayMode: DisplayMode,
+    selectableDates: SelectableDates = DatePickerDefaults.AllDates,
+) {
+    /**
+     * The [SelectableDates] rule deciding which days can be picked. Use [DateBounds] for a
+     * minimum and maximum day, and [and] to combine rules. Honoured by the Material picker and
+     * by the iOS 16+ calendar, where rejected days are greyed out; bounds coming from a
+     * [DateBounds] are also applied natively. [SelectableDates.isSelectableYear] only affects
+     * Material. Observable.
+     */
+    var selectableDates: SelectableDates by mutableStateOf(selectableDates)
+
+    /** The bounds the rule enforces natively; open on both sides for rules without bounds. */
+    internal val dateBounds: DateBounds
+        get() = selectableDates.dateBoundsOrNull() ?: DateBounds()
+
+    private val materialState: DateRangePickerState =
+        DateRangePickerState(
+            locale = getCalendarLocalDefault(),
+            initialSelectedStartDateMillis = initialSelectedStartDateMillis,
+            initialSelectedEndDateMillis = initialSelectedEndDateMillis,
+            initialDisplayedMonthMillis = initialDisplayedMonthMillis,
+            yearRange = yearRange,
+            initialDisplayMode = initialMaterialDisplayMode,
+        )
+
+    /**
+     * The Material3 state this state delegates to. It reports [selectableDates] as its rule,
+     * so the Material3 picker follows every change.
+     */
+    // `this.` is required: the constructor parameter of the same name would be captured otherwise.
+    val dateRangePickerState: DateRangePickerState =
+        RuleTrackingDateRangePickerState(materialState) { this.selectableDates }
+
+    /** The _start_ of the selected start day in _UTC_ milliseconds, or `null`. */
+    val selectedStartDateMillis: Long?
+        get() = dateRangePickerState.selectedStartDateMillis
+
+    /** The _start_ of the selected end day in _UTC_ milliseconds, or `null`. */
+    val selectedEndDateMillis: Long?
+        get() = dateRangePickerState.selectedEndDateMillis
+
+    /** The display mode on Material platforms (calendar or text input). */
+    var displayMode: DisplayMode
+        get() = dateRangePickerState.displayMode
+        set(value) {
+            dateRangePickerState.displayMode = value
+        }
+
+    /**
+     * Sets the selected range.
+     *
+     * @param startDateMillis the start day in _UTC_ milliseconds, or `null` to clear the range.
+     * @param endDateMillis the end day in _UTC_ milliseconds, or `null` for an open range.
+     *
+     * A `null` or out-of-[yearRange] start clears the whole selection, and so does an end
+     * before the start. A `null` or out-of-range end only drops the end and keeps the start.
+     */
+    fun setSelection(startDateMillis: Long?, endDateMillis: Long?) {
+        dateRangePickerState.setSelection(startDateMillis, endDateMillis)
+    }
+
+    internal fun isDaySelectable(utcTimeMillis: Long): Boolean =
+        selectableDates.isSelectableDate(utcTimeMillis)
+
+    companion object {
+        /**
+         * The default [Saver] implementation for [AdaptiveDateRangePickerState].
+         *
+         * @param selectableDates the rule to re-attach on restore, since it cannot be saved.
+         */
+        fun Saver(
+            selectableDates: SelectableDates = DatePickerDefaults.AllDates,
+        ): Saver<AdaptiveDateRangePickerState, Any> =
+            listSaver(
+                save = {
+                    listOf(
+                        it.selectedStartDateMillis,
+                        it.selectedEndDateMillis,
+                        it.dateRangePickerState.displayedMonthMillis,
+                        it.yearRange.first,
+                        it.yearRange.last,
+                        it.displayMode.value,
+                    )
+                },
+                restore = { value ->
+                    AdaptiveDateRangePickerState(
+                        initialSelectedStartDateMillis = value[0] as Long?,
+                        initialSelectedEndDateMillis = value[1] as Long?,
+                        initialDisplayedMonthMillis = value[2] as Long?,
+                        yearRange = IntRange(value[3] as Int, value[4] as Int),
+                        initialMaterialDisplayMode = displayModeFromValue(value[5] as Int),
+                        selectableDates = selectableDates,
+                    )
+                },
+            )
+    }
+}

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateRangeSelection.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateRangeSelection.kt
@@ -1,0 +1,27 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+/**
+ * The start and end of a date range as UTC start-of-day timestamps, and how taps on a
+ * calendar change it: the first tap sets the start, a tap on or after the start sets the end,
+ * a tap before the start moves the start, and any tap on a completed range starts over.
+ */
+internal data class DateRangeSelection(
+    val start: Long?,
+    val end: Long?,
+) {
+    fun afterTap(utcTimeMillis: Long): DateRangeSelection {
+        val currentStart = start
+        return when {
+            currentStart == null || end != null -> DateRangeSelection(start = utcTimeMillis, end = null)
+            utcTimeMillis < currentStart -> DateRangeSelection(start = utcTimeMillis, end = null)
+            else -> DateRangeSelection(start = currentStart, end = utcTimeMillis)
+        }
+    }
+
+    /** Every day of the range as UTC start-of-day timestamps; only the start while the end is unset. */
+    fun days(): List<Long> {
+        val firstDay = start?.floorDiv(MILLIS_PER_DAY) ?: return emptyList()
+        val lastDay = end?.floorDiv(MILLIS_PER_DAY) ?: firstDay
+        return (firstDay..lastDay).map { day -> day * MILLIS_PER_DAY }
+    }
+}

--- a/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/RuleTrackingDateRangePickerState.kt
+++ b/calf-ui/src/commonMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/RuleTrackingDateRangePickerState.kt
@@ -1,0 +1,18 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DateRangePickerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+
+/**
+ * A [DateRangePickerState] that reports the rule returned by [currentRule] instead of the one
+ * it was created with, for the same reason as [RuleTrackingDatePickerState].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+internal class RuleTrackingDateRangePickerState(
+    delegate: DateRangePickerState,
+    private val currentRule: () -> SelectableDates,
+) : DateRangePickerState by delegate {
+    override val selectableDates: SelectableDates
+        get() = currentRule()
+}

--- a/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateRangeSelectionTest.kt
+++ b/calf-ui/src/commonTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/DateRangeSelectionTest.kt
@@ -1,0 +1,57 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DateRangeSelectionTest {
+
+    @Test
+    fun `first tap starts a new range`() {
+        assertEquals(
+            DateRangeSelection(start = MAR_14_2026, end = null),
+            DateRangeSelection(start = null, end = null).afterTap(MAR_14_2026),
+        )
+    }
+
+    @Test
+    fun `tapping after the start completes the range`() {
+        assertEquals(
+            DateRangeSelection(start = MAR_14_2026, end = MAR_16_2026),
+            DateRangeSelection(start = MAR_14_2026, end = null).afterTap(MAR_16_2026),
+        )
+    }
+
+    @Test
+    fun `tapping the start day again makes a single-day range`() {
+        assertEquals(
+            DateRangeSelection(start = MAR_14_2026, end = MAR_14_2026),
+            DateRangeSelection(start = MAR_14_2026, end = null).afterTap(MAR_14_2026),
+        )
+    }
+
+    @Test
+    fun `tapping before the start moves the start`() {
+        assertEquals(
+            DateRangeSelection(start = MAR_13_2026, end = null),
+            DateRangeSelection(start = MAR_14_2026, end = null).afterTap(MAR_13_2026),
+        )
+    }
+
+    @Test
+    fun `tapping while a range is complete starts over`() {
+        assertEquals(
+            DateRangeSelection(start = MAR_1_2026, end = null),
+            DateRangeSelection(start = MAR_14_2026, end = MAR_16_2026).afterTap(MAR_1_2026),
+        )
+    }
+
+    @Test
+    fun `days in range lists every day start from start to end inclusive`() {
+        assertEquals(
+            listOf(MAR_13_2026, MAR_14_2026, MAR_15_2026, MAR_16_2026),
+            DateRangeSelection(start = MAR_13_2026, end = MAR_16_2026).days(),
+        )
+        assertEquals(listOf(MAR_14_2026), DateRangeSelection(start = MAR_14_2026, end = null).days())
+        assertEquals(emptyList(), DateRangeSelection(start = null, end = null).days())
+    }
+}

--- a/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePickerStateTest.kt
+++ b/calf-ui/src/desktopTest/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePickerStateTest.kt
@@ -1,0 +1,168 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DisplayMode
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.SaverScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
+class AdaptiveDateRangePickerStateTest {
+
+    private val march = DateBounds(minDateMillis = MAR_1_2026, maxDateMillis = MAR_31_2026)
+
+    private fun state(
+        selectableDates: SelectableDates = DatePickerDefaults.AllDates,
+    ) = AdaptiveDateRangePickerState(
+        initialSelectedStartDateMillis = null,
+        initialSelectedEndDateMillis = null,
+        initialDisplayedMonthMillis = null,
+        yearRange = DatePickerDefaults.YearRange,
+        initialMaterialDisplayMode = DisplayMode.Picker,
+        selectableDates = selectableDates,
+    )
+
+    @Test
+    fun `selection exposes start and end`() {
+        val state = state()
+
+        state.setSelection(MAR_13_2026, MAR_16_2026)
+
+        assertEquals(MAR_13_2026, state.selectedStartDateMillis)
+        assertEquals(MAR_16_2026, state.selectedEndDateMillis)
+    }
+
+    @Test
+    fun `an end before the start clears the selection`() {
+        val state = state()
+        state.setSelection(MAR_13_2026, MAR_16_2026)
+
+        state.setSelection(MAR_16_2026, MAR_13_2026)
+
+        assertNull(state.selectedStartDateMillis)
+        assertNull(state.selectedEndDateMillis)
+    }
+
+    @Test
+    fun `selectable dates follow the bounds and the rule`() {
+        val selectable = state(selectableDates = march and WeekdaysOnly).dateRangePickerState.selectableDates
+
+        assertFalse(selectable.isSelectableDate(FEB_28_2026))
+        assertTrue(selectable.isSelectableDate(MAR_13_2026))
+        assertFalse(selectable.isSelectableDate(MAR_14_2026))
+        assertFalse(selectable.isSelectableDate(APR_1_2026))
+        assertFalse(selectable.isSelectableYear(2025))
+        assertTrue(selectable.isSelectableYear(2026))
+    }
+
+    @Test
+    fun `the material state exposes the current rule as a new object after a change`() {
+        val state = state()
+        val before = state.dateRangePickerState.selectableDates
+        assertTrue(before.isSelectableDate(FEB_28_2026))
+
+        state.selectableDates = DateBounds(minDateMillis = MAR_1_2026)
+
+        val after = state.dateRangePickerState.selectableDates
+        assertFalse(after.isSelectableDate(FEB_28_2026))
+        assertTrue(before !== after)
+    }
+
+    @Test
+    fun `changing the rule disables the rejected days in the range calendar`() = runComposeUiTest {
+        var rule: SelectableDates by mutableStateOf(DatePickerDefaults.AllDates)
+        setContent {
+            val state = rememberAdaptiveDateRangePickerState(
+                initialSelectedStartDateMillis = MAR_15_2026,
+                selectableDates = rule,
+            )
+            AdaptiveDateRangePicker(state = state)
+        }
+        waitForIdle()
+        dayCell(MAR_14_2026).assertIsEnabled()
+
+        rule = WeekdaysOnly
+        waitForIdle()
+
+        dayCell(MAR_14_2026).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `saver round-trips the selection and re-attaches the rule`() {
+        val saver = AdaptiveDateRangePickerState.Saver(march)
+        val original = state(selectableDates = march)
+        original.setSelection(MAR_13_2026, MAR_16_2026)
+
+        val saved = requireNotNull(with(saver) { SaverScope { true }.save(original) })
+        val restored = requireNotNull(saver.restore(saved))
+
+        assertEquals(MAR_13_2026, restored.selectedStartDateMillis)
+        assertEquals(MAR_16_2026, restored.selectedEndDateMillis)
+        assertEquals(march, restored.selectableDates)
+        assertNull(state().selectedStartDateMillis)
+    }
+
+    @Test
+    fun `a rule can reject a year inside the bounds`() {
+        val noYear2026 = object : SelectableDates {
+            override fun isSelectableYear(year: Int): Boolean = year != 2026
+        }
+        val selectable = state(selectableDates = noYear2026).dateRangePickerState.selectableDates
+
+        assertFalse(selectable.isSelectableYear(2026))
+        assertTrue(selectable.isSelectableYear(2027))
+    }
+
+    @Test
+    fun `range picker renders the month of the selection`() = runComposeUiTest {
+        val state = AdaptiveDateRangePickerState(
+            initialSelectedStartDateMillis = MAR_13_2026,
+            initialSelectedEndDateMillis = MAR_16_2026,
+            initialDisplayedMonthMillis = MAR_13_2026,
+            yearRange = DatePickerDefaults.YearRange,
+            initialMaterialDisplayMode = DisplayMode.Picker,
+        )
+        val startDayDescription = requireNotNull(
+            DatePickerDefaults.dateFormatter()
+                .formatDate(MAR_13_2026, getCalendarLocalDefault(), forContentDescription = true),
+        )
+
+        setContent {
+            AdaptiveDateRangePicker(state = state)
+        }
+
+        val describesStartDay = hasText(startDayDescription, substring = true) or
+            hasContentDescription(startDayDescription, substring = true)
+        assertTrue(onAllNodes(describesStartDay).fetchSemanticsNodes().isNotEmpty())
+    }
+
+    @Test
+    fun `range picker can be placed in a vertically scrolling column`() = runComposeUiTest {
+        val state = state()
+
+        setContent {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                AdaptiveDateRangePicker(state = state)
+            }
+        }
+        waitForIdle()
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePicker.ios.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePicker.ios.kt
@@ -1,0 +1,115 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DatePickerColors
+import androidx.compose.material3.DatePickerFormatter
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalAbsoluteTonalElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
+import androidx.compose.ui.viewinterop.UIKitInteropProperties
+import androidx.compose.ui.viewinterop.UIKitView
+import com.mohamedrejeb.calf.ui.utils.applyLayoutDirection
+import com.mohamedrejeb.calf.ui.utils.isIOSVersionAtLeast
+import com.mohamedrejeb.calf.ui.utils.surfaceColorAtElevation
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+actual fun AdaptiveDateRangePicker(
+    state: AdaptiveDateRangePickerState,
+    modifier: Modifier,
+    dateFormatter: DatePickerFormatter,
+    title: (@Composable () -> Unit)?,
+    headline: (@Composable () -> Unit)?,
+    showModeToggle: Boolean,
+    colors: DatePickerColors,
+) {
+    if (!isIOSVersionAtLeast(FIRST_IOS_WITH_CALENDAR_VIEW)) {
+        MaterialDateRangePicker(
+            state = state,
+            modifier = modifier,
+            dateFormatter = dateFormatter,
+            title = title,
+            headline = headline,
+            showModeToggle = showModeToggle,
+            colors = colors,
+        )
+        return
+    }
+
+    // Recreated if a different state is passed, so taps never reach a stale state.
+    val backend = remember(state) {
+        CalendarRangePickerBackend(
+            initialSelection = DateRangeSelection(
+                start = state.selectedStartDateMillis,
+                end = state.selectedEndDateMillis,
+            ),
+            onSelectionChanged = { selection ->
+                state.setSelection(selection.start, selection.end)
+            },
+            isDaySelectable = { dateMillis ->
+                state.isDaySelectable(dateMillis)
+            },
+        )
+    }
+    val aspectRatio = remember(backend) {
+        backend.aspectRatio.takeIf { it > 0f } ?: inlineDatePickerAspectRatio()
+    }
+
+    val layoutDirection = LocalLayoutDirection.current
+    val absoluteElevation = LocalAbsoluteTonalElevation.current
+    val containerColorAtElevation = surfaceColorAtElevation(
+        color = colors.containerColor,
+        elevation = absoluteElevation,
+    )
+
+    LaunchedEffect(layoutDirection) {
+        backend.view.applyLayoutDirection(layoutDirection)
+    }
+
+    LaunchedEffect(state.selectableDates) {
+        val bounds = state.dateBounds
+        backend.applyDateBounds(bounds.minDateMillis, bounds.maxDateMillis)
+    }
+
+    LaunchedEffect(state.selectedStartDateMillis, state.selectedEndDateMillis) {
+        backend.setSelectedRange(
+            DateRangeSelection(
+                start = state.selectedStartDateMillis,
+                end = state.selectedEndDateMillis,
+            ),
+        )
+    }
+
+    LaunchedEffect(colors, containerColorAtElevation) {
+        backend.applyColors(
+            containerColor = containerColorAtElevation,
+            dayContentColor = colors.dayContentColor,
+            selectedDayContainerColor = colors.selectedDayContainerColor,
+        )
+    }
+
+    Box(modifier = modifier) {
+        key(backend) {
+            UIKitView(
+                factory = { backend.view },
+                properties = UIKitInteropProperties(
+                    interactionMode = UIKitInteropInteractionMode.NonCooperative,
+                ),
+                modifier = Modifier
+                    .background(colors.containerColor)
+                    .fillMaxWidth()
+                    .aspectRatio(aspectRatio),
+            )
+        }
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarDatePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarDatePickerBackend.kt
@@ -4,30 +4,12 @@ package com.mohamedrejeb.calf.ui.datepicker
 
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCSignatureOverride
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.minus
-import kotlinx.datetime.number
-import kotlinx.datetime.plus
-import platform.Foundation.NSCalendar
-import platform.Foundation.NSDate
 import platform.Foundation.NSDateComponents
-import platform.Foundation.NSDateInterval
-import platform.Foundation.NSTimeZone
-import platform.Foundation.distantFuture
-import platform.Foundation.distantPast
-import platform.Foundation.localTimeZone
 import platform.UIKit.UICalendarSelectionSingleDate
 import platform.UIKit.UICalendarSelectionSingleDateDelegateProtocol
-import platform.UIKit.UICalendarView
-import platform.UIKit.UICalendarViewDecoration
-import platform.UIKit.UICalendarViewDelegateProtocol
 import platform.UIKit.UIColor
 import platform.UIKit.UIView
 import platform.darwin.NSObject
-
-private const val MAX_SUPPORTED_YEAR = 9999L
-private const val MAX_MONTH = 12L
 
 /**
  * Inline calendar backed by `UICalendarView` (iOS 16+). Days rejected by [isDaySelectable]
@@ -39,7 +21,7 @@ internal class CalendarDatePickerBackend(
     private val isDaySelectable: (utcTimeMillis: Long) -> Boolean,
 ) : IosDatePickerBackend {
 
-    private val calendarView = UICalendarView()
+    private val host = CalendarViewHost()
 
     private val selectionDelegate = object : NSObject(), UICalendarSelectionSingleDateDelegateProtocol {
         @ObjCSignatureOverride
@@ -62,29 +44,16 @@ internal class CalendarDatePickerBackend(
 
     private val selection = UICalendarSelectionSingleDate(delegate = selectionDelegate)
 
-    /** Draws no decorations, but lets [refresh] ask the calendar to rebuild its day cells. */
-    private val decorationDelegate = object : NSObject(), UICalendarViewDelegateProtocol {
-        @ObjCSignatureOverride
-        override fun calendarView(
-            calendarView: UICalendarView,
-            decorationForDateComponents: NSDateComponents,
-        ): UICalendarViewDecoration? = null
-    }
-
     override val view: UIView
-        get() = calendarView
+        get() = host.calendarView
 
     init {
-        calendarView.calendar = NSCalendar.currentCalendar
-        calendarView.locale = getCalendarLocalDefault()
-        calendarView.timeZone = NSTimeZone.localTimeZone
-        calendarView.delegate = decorationDelegate
-        calendarView.selectionBehavior = selection
+        host.calendarView.selectionBehavior = selection
         initialSelectedDateMillis?.let { millis ->
             selection.setSelectedDate(utcDayToDateComponents(millis), animated = false)
-            calendarView.setVisibleDateComponents(utcDayToDateComponents(millis), animated = false)
+            host.showMonth(millis, animated = false)
         }
-        calendarView.sizeToFit()
+        host.calendarView.sizeToFit()
     }
 
     override fun setSelectedDate(utcTimeMillis: Long?) {
@@ -92,63 +61,24 @@ internal class CalendarDatePickerBackend(
         if (current == utcTimeMillis) return
 
         selection.setSelectedDate(utcTimeMillis?.let(::utcDayToDateComponents), animated = true)
-        utcTimeMillis?.let { millis ->
-            calendarView.setVisibleDateComponents(utcDayToDateComponents(millis), animated = true)
-        }
+        utcTimeMillis?.let { millis -> host.showMonth(millis, animated = true) }
     }
 
     override fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?) {
-        val start = minDateMillis?.let(::localStartOfDay) ?: NSDate.distantPast
-        val end = maxDateMillis?.let(::localEndOfDay) ?: NSDate.distantFuture
-        calendarView.availableDateRange = NSDateInterval(startDate = start, endDate = end)
+        host.applyDateBounds(minDateMillis, maxDateMillis)
     }
 
     override fun updateSelectableDates() {
         selection.updateSelectableDates()
-        refresh()
+        host.refresh()
     }
 
     override fun setEnabled(enabled: Boolean) {
-        calendarView.userInteractionEnabled = enabled
-    }
-
-    /**
-     * Rebuilds the days around the visible month, so bounds and rule changes show right away
-     * instead of on the next scroll or tap.
-     */
-    private fun refresh() {
-        val days = daysAroundVisibleMonth()
-        if (days.isNotEmpty()) {
-            calendarView.reloadDecorationsForDateComponents(days, animated = false)
-        }
-        calendarView.setNeedsLayout()
-        calendarView.layoutIfNeeded()
-    }
-
-    /** Every day of the visible month and its two neighbours, which may be partly on screen. */
-    private fun daysAroundVisibleMonth(): List<NSDateComponents> {
-        val visible = calendarView.visibleDateComponents
-        val year = visible.year
-        val month = visible.month
-        if (year !in 1..MAX_SUPPORTED_YEAR || month !in 1..MAX_MONTH) return emptyList()
-
-        val firstOfMonth = LocalDate(year.toInt(), month.toInt(), 1)
-        val start = firstOfMonth.minus(1, DateTimeUnit.MONTH)
-        val end = firstOfMonth.plus(2, DateTimeUnit.MONTH)
-        return generateSequence(start) { it.plus(1, DateTimeUnit.DAY) }
-            .takeWhile { it < end }
-            .map { date ->
-                NSDateComponents().apply {
-                    this.year = date.year.toLong()
-                    this.month = date.month.number.toLong()
-                    this.day = date.day.toLong()
-                }
-            }
-            .toList()
+        host.setEnabled(enabled)
     }
 
     override fun applyColors(containerColor: UIColor, selectedDayContainerColor: UIColor) {
-        calendarView.tintColor = selectedDayContainerColor
-        calendarView.backgroundColor = containerColor
+        host.calendarView.tintColor = selectedDayContainerColor
+        host.calendarView.backgroundColor = containerColor
     }
 }

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarRangePickerBackend.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarRangePickerBackend.kt
@@ -1,0 +1,107 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.ui.graphics.Color
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCSignatureOverride
+import platform.Foundation.NSDateComponents
+import platform.UIKit.UICalendarSelectionMultiDate
+import platform.UIKit.UICalendarSelectionMultiDateDelegateProtocol
+import platform.UIKit.UIView
+import platform.darwin.NSObject
+
+/**
+ * Range calendar backed by `UICalendarView` (iOS 16+) with multi-date selection. Taps are
+ * folded into a [DateRangeSelection], and every day of the range is highlighted. Days rejected
+ * by [isDaySelectable] are greyed out.
+ */
+internal class CalendarRangePickerBackend(
+    initialSelection: DateRangeSelection,
+    private val onSelectionChanged: (selection: DateRangeSelection) -> Unit,
+    private val isDaySelectable: (utcTimeMillis: Long) -> Boolean,
+) {
+    private val host = CalendarViewHost()
+
+    private var selection = initialSelection
+
+    private val selectionDelegate = object : NSObject(), UICalendarSelectionMultiDateDelegateProtocol {
+        @ObjCSignatureOverride
+        override fun multiDateSelection(
+            selection: UICalendarSelectionMultiDate,
+            didSelectDate: NSDateComponents,
+        ) {
+            onTap(didSelectDate.toUtcDayMillis())
+        }
+
+        @ObjCSignatureOverride
+        override fun multiDateSelection(
+            selection: UICalendarSelectionMultiDate,
+            didDeselectDate: NSDateComponents,
+        ) {
+            onTap(didDeselectDate.toUtcDayMillis())
+        }
+
+        @ObjCSignatureOverride
+        override fun multiDateSelection(
+            selection: UICalendarSelectionMultiDate,
+            canSelectDate: NSDateComponents,
+        ): Boolean = isDaySelectable(canSelectDate.toUtcDayMillis())
+
+        @ObjCSignatureOverride
+        override fun multiDateSelection(
+            selection: UICalendarSelectionMultiDate,
+            canDeselectDate: NSDateComponents,
+        ): Boolean = true
+    }
+
+    private val multiSelection = UICalendarSelectionMultiDate(delegate = selectionDelegate)
+
+    val view: UIView
+        get() = host.calendarView
+
+    /** Width divided by height of the calendar, or 0 when it has no intrinsic size yet. */
+    val aspectRatio: Float
+
+    init {
+        host.calendarView.selectionBehavior = multiSelection
+        render(animated = false)
+        selection.start?.let { host.showMonth(it, animated = false) }
+        host.calendarView.sizeToFit()
+        aspectRatio = host.calendarView.aspectRatioOrZero()
+    }
+
+    private fun onTap(utcTimeMillis: Long) {
+        selection = selection.afterTap(utcTimeMillis)
+        render(animated = true)
+        onSelectionChanged(selection)
+    }
+
+    private fun render(animated: Boolean) {
+        val highlightedDays = selection.days()
+            .filter(isDaySelectable)
+            .map(::utcDayToDateComponents)
+        multiSelection.setSelectedDates(highlightedDays, animated = animated)
+    }
+
+    fun setSelectedRange(newSelection: DateRangeSelection) {
+        if (newSelection == selection) return
+        selection = newSelection
+        render(animated = true)
+        newSelection.start?.let { host.showMonth(it, animated = true) }
+    }
+
+    fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?) {
+        host.applyDateBounds(minDateMillis, maxDateMillis)
+        updateSelectableDates()
+    }
+
+    fun updateSelectableDates() {
+        multiSelection.updateSelectableDates()
+        host.refresh()
+    }
+
+    fun applyColors(containerColor: Color, dayContentColor: Color, selectedDayContainerColor: Color) {
+        host.applyColors(containerColor, dayContentColor, selectedDayContainerColor)
+    }
+}

--- a/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarViewHost.kt
+++ b/calf-ui/src/iosMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/CalendarViewHost.kt
@@ -1,0 +1,108 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.ui.graphics.Color
+import com.mohamedrejeb.calf.ui.utils.applyTheme
+import com.mohamedrejeb.calf.ui.utils.isDark
+import com.mohamedrejeb.calf.ui.utils.toUIColor
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCSignatureOverride
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.number
+import kotlinx.datetime.plus
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateComponents
+import platform.Foundation.NSDateInterval
+import platform.Foundation.NSTimeZone
+import platform.Foundation.distantFuture
+import platform.Foundation.distantPast
+import platform.Foundation.localTimeZone
+import platform.UIKit.UICalendarView
+import platform.UIKit.UICalendarViewDecoration
+import platform.UIKit.UICalendarViewDelegateProtocol
+import platform.darwin.NSObject
+
+private const val MAX_SUPPORTED_YEAR = 9999L
+private const val MAX_MONTH = 12L
+
+/** A `UICalendarView` (iOS 16+) configured for the device calendar, shared by the calendar backends. */
+internal class CalendarViewHost {
+
+    val calendarView: UICalendarView = UICalendarView().apply {
+        calendar = NSCalendar.currentCalendar
+        locale = getCalendarLocalDefault()
+        timeZone = NSTimeZone.localTimeZone
+    }
+
+    /** Draws no decorations, but lets [refresh] ask the calendar to rebuild its day cells. */
+    private val decorationDelegate = object : NSObject(), UICalendarViewDelegateProtocol {
+        @ObjCSignatureOverride
+        override fun calendarView(
+            calendarView: UICalendarView,
+            decorationForDateComponents: NSDateComponents,
+        ): UICalendarViewDecoration? = null
+    }
+
+    init {
+        calendarView.delegate = decorationDelegate
+    }
+
+    fun showMonth(utcTimeMillis: Long, animated: Boolean) {
+        calendarView.setVisibleDateComponents(utcDayToDateComponents(utcTimeMillis), animated = animated)
+    }
+
+    fun applyDateBounds(minDateMillis: Long?, maxDateMillis: Long?) {
+        val start = minDateMillis?.let(::localStartOfDay) ?: NSDate.distantPast
+        val end = maxDateMillis?.let(::localEndOfDay) ?: NSDate.distantFuture
+        calendarView.availableDateRange = NSDateInterval(startDate = start, endDate = end)
+    }
+
+    /**
+     * Rebuilds the days around the visible month, so bounds and rule changes show right away
+     * instead of on the next scroll or tap.
+     */
+    fun refresh() {
+        val days = daysAroundVisibleMonth()
+        if (days.isNotEmpty()) {
+            calendarView.reloadDecorationsForDateComponents(days, animated = false)
+        }
+        calendarView.setNeedsLayout()
+        calendarView.layoutIfNeeded()
+    }
+
+    fun applyColors(containerColor: Color, dayContentColor: Color, selectedDayContainerColor: Color) {
+        calendarView.applyTheme(dark = !isDark(dayContentColor))
+        calendarView.tintColor = selectedDayContainerColor.toUIColor()
+        calendarView.backgroundColor = containerColor.toUIColor()
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        calendarView.userInteractionEnabled = enabled
+    }
+
+    /** Every day of the visible month and its two neighbours, which may be partly on screen. */
+    private fun daysAroundVisibleMonth(): List<NSDateComponents> {
+        val visible = calendarView.visibleDateComponents
+        val year = visible.year
+        val month = visible.month
+        if (year !in 1..MAX_SUPPORTED_YEAR || month !in 1..MAX_MONTH) return emptyList()
+
+        val firstOfMonth = LocalDate(year.toInt(), month.toInt(), 1)
+        val start = firstOfMonth.minus(1, DateTimeUnit.MONTH)
+        val end = firstOfMonth.plus(2, DateTimeUnit.MONTH)
+        return generateSequence(start) { it.plus(1, DateTimeUnit.DAY) }
+            .takeWhile { it < end }
+            .map { date ->
+                NSDateComponents().apply {
+                    this.year = date.year.toLong()
+                    this.month = date.month.number.toLong()
+                    this.day = date.day.toLong()
+                }
+            }
+            .toList()
+    }
+}

--- a/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePicker.material.kt
+++ b/calf-ui/src/materialMain/kotlin/com/mohamedrejeb/calf/ui/datepicker/AdaptiveDateRangePicker.material.kt
@@ -1,0 +1,29 @@
+package com.mohamedrejeb.calf.ui.datepicker
+
+import androidx.compose.material3.DatePickerColors
+import androidx.compose.material3.DatePickerFormatter
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+actual fun AdaptiveDateRangePicker(
+    state: AdaptiveDateRangePickerState,
+    modifier: Modifier,
+    dateFormatter: DatePickerFormatter,
+    title: (@Composable () -> Unit)?,
+    headline: (@Composable () -> Unit)?,
+    showModeToggle: Boolean,
+    colors: DatePickerColors,
+) {
+    MaterialDateRangePicker(
+        state = state,
+        modifier = modifier,
+        dateFormatter = dateFormatter,
+        title = title,
+        headline = headline,
+        showModeToggle = showModeToggle,
+        colors = colors,
+    )
+}

--- a/docs/ui/adaptive-date-picker.md
+++ b/docs/ui/adaptive-date-picker.md
@@ -1,11 +1,12 @@
 # Date Picker
 
-Calf provides two date pickers that adapt to the platform they run on:
+Calf provides three date pickers that adapt to the platform they run on:
 
 1. **AdaptiveDatePicker**: the full calendar, always visible. Material3 `DatePicker` on Android, Desktop and Web; `UICalendarView` (iOS 16+) or `UIDatePicker` on iOS.
 2. **AdaptiveCompactDatePicker**: a field showing the selected date that opens the calendar on tap. A `DatePickerDialog` on Material platforms; the system compact `UIDatePicker` on iOS.
+3. **AdaptiveDateRangePicker**: picks a start and an end day. Material3 `DateRangePicker` on Material platforms; a native multi-date `UICalendarView` on iOS 16+.
 
-Both share `AdaptiveDatePickerState` and support the same [selectable rules](#restricting-selectable-dates).
+The first two share `AdaptiveDatePickerState`, the range picker has its own `AdaptiveDateRangePickerState`. All of them support the same [selectable rules](#restricting-selectable-dates).
 
 ## Usage
 
@@ -95,7 +96,7 @@ Pass a stable instance, such as an `object`, a data class or a remembered value,
 | Platform | Behaviour |
 |---|---|
 | Material (Android, Desktop, Web) | Rejected days are disabled in the calendar grid. `isSelectableYear` disables years in the year picker. |
-| iOS 16+ inline calendar (`UIKitDisplayMode.Picker`) | Backed by `UICalendarView`: rejected days are greyed out and cannot be tapped. Bounds coming from a `DateBounds` also hide the months outside the range. |
+| iOS 16+ calendars (inline and range) | Backed by `UICalendarView`: rejected days are greyed out and cannot be tapped. Bounds coming from a `DateBounds` also hide the months outside the range. |
 | iOS compact picker, wheels (`UIKitDisplayMode.Wheels`) and inline below iOS 16 | Backed by `UIDatePicker`, which cannot grey out days. Bounds coming from a `DateBounds` apply natively; picking any other rejected day snaps the control to the nearest selectable day. |
 
 On every platform, a current selection that a new rule rejects is moved to the nearest selectable day. `isSelectableYear` has no effect on iOS.
@@ -121,5 +122,27 @@ AdaptiveCompactDatePicker(
 |---|---|
 | Material (Android, Desktop, Web) | An outlined button with the formatted date opens a `DatePickerDialog`. The day picked in the dialog reaches the state only on confirm; dismiss, or tapping outside, discards it. |
 | iOS | The system compact `UIDatePicker`, which pops its calendar over the content. Changes apply immediately, as they do everywhere in iOS. Bounds coming from a `DateBounds` apply natively; the control cannot grey out days any other rule rejects, so such a pick snaps to the nearest selectable day. |
+
+## Range picker
+
+`AdaptiveDateRangePicker` selects a start and an end day. Its state exposes `selectedStartDateMillis` and `selectedEndDateMillis`, both UTC start-of-day timestamps, and `setSelection(start, end)`.
+
+```kotlin
+val rangeState = rememberAdaptiveDateRangePickerState(
+    selectableDates = DateBounds(minDateMillis = todayMillis) and weekdaysOnly,
+)
+
+AdaptiveDateRangePicker(state = rangeState)
+
+Text("From ${rangeState.selectedStartDateMillis} to ${rangeState.selectedEndDateMillis}")
+```
+
+| Platform | Behaviour |
+|---|---|
+| Material (Android, Desktop, Web) | The Material3 `DateRangePicker`, including its text input mode. It scrolls through months, so it needs a bounded height: inside a vertically scrolling column it falls back to `DateRangePickerFallbackHeight` (568 dp) unless you pass a `height` modifier. |
+| iOS 16+ | A native `UICalendarView` with multi-date selection. The first tap picks the start, a tap on or after it picks the end, a tap before it moves the start, and any tap on a completed range starts a new one. Every day of the range is highlighted, rejected days are greyed out. |
+| iOS below 16 | The Material3 `DateRangePicker`. |
+
+Unlike the single-date state, a range is not moved automatically when the rule changes. It is validated when set: an end before the start, or an end without a start, clears the whole selection.
 
 > `AdaptiveDatePicker` has no `dateValidator` parameter. An earlier version of this page documented one that never existed. Use `selectableDates` with `DateBounds` as described above instead.

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/Screen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/navigation/Screen.kt
@@ -99,7 +99,7 @@ enum class Screen(
     ),
     DatePicker(
         title = "Adaptive Date Picker",
-        description = "Inline and compact date pickers with the native iOS calendar and Material3",
+        description = "Inline, compact and range date pickers with the native iOS calendar and Material3",
         icon = Icons.Outlined.CalendarMonth,
         category = ScreenCategory.Pickers,
     ),

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/DatePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/DatePickerScreen.kt
@@ -32,10 +32,12 @@ import com.mohamedrejeb.calf.sample.components.SampleScreenScaffold
 import com.mohamedrejeb.calf.sample.currentPlatform
 import com.mohamedrejeb.calf.ui.datepicker.AdaptiveCompactDatePicker
 import com.mohamedrejeb.calf.ui.datepicker.AdaptiveDatePicker
+import com.mohamedrejeb.calf.ui.datepicker.AdaptiveDateRangePicker
 import com.mohamedrejeb.calf.ui.datepicker.DateBounds
 import com.mohamedrejeb.calf.ui.datepicker.UIKitDisplayMode
 import com.mohamedrejeb.calf.ui.datepicker.and
 import com.mohamedrejeb.calf.ui.datepicker.rememberAdaptiveDatePickerState
+import com.mohamedrejeb.calf.ui.datepicker.rememberAdaptiveDateRangePickerState
 import com.mohamedrejeb.calf.ui.toggle.AdaptiveSwitch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
@@ -95,6 +97,7 @@ fun DatePickerScreen(
 
     val inlineState = rememberAdaptiveDatePickerState(selectableDates = selectableDates)
     val compactState = rememberAdaptiveDatePickerState(selectableDates = selectableDates)
+    val rangeState = rememberAdaptiveDateRangePickerState(selectableDates = selectableDates)
     val wheelsState = rememberAdaptiveDatePickerState(
         initialUIKitDisplayMode = UIKitDisplayMode.Wheels,
         selectableDates = selectableDates,
@@ -112,7 +115,7 @@ fun DatePickerScreen(
                 .padding(16.dp)
         ) {
             Text(
-                text = "Inline and compact date pickers backed by the native iOS controls " +
+                text = "Inline, compact and range date pickers backed by the native iOS controls " +
                     "and the Material3 pickers. The controls below restrict every picker on this screen.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -178,6 +181,27 @@ fun DatePickerScreen(
                     colors = sampleDatePickerColors(),
                 )
             }
+
+            SectionDivider()
+
+            SectionTitle(
+                title = "Range picker",
+                description = "Tap a start day, then an end day. Tap again to start a new range.",
+            )
+
+            Text(
+                text = "Range: ${rangeState.selectedStartDateMillis.toDateLabel()} " +
+                    "to ${rangeState.selectedEndDateMillis.toDateLabel()}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            AdaptiveDateRangePicker(
+                state = rangeState,
+                colors = sampleDatePickerColors(),
+            )
 
             SectionDivider()
 


### PR DESCRIPTION
A range picker with its own AdaptiveDateRangePickerState: one common class wrapping Material3's DateRangePickerState on every platform, with the same selectable-dates rule as the single-date pickers. The Material3 state is wrapped so it reports the caller's rule object, which keeps the Material3 picker in sync when the rule changes.

- Material: the Material3 DateRangePicker. It scrolls its months and cannot take an unbounded height, so inside a scrolling column it falls back to DateRangePickerFallbackHeight instead of crashing
- iOS 16+: a native UICalendarView with multi-date selection driven by a pure DateRangeSelection reducer (first tap sets the start, a tap on or after it sets the end, a tap before it moves the start, any tap on a complete range starts over); every day of the range is highlighted and rejected days are greyed out. Below iOS 16 the Material3 picker is shown
- iOS: the UICalendarView setup, including the refresh of visible days after rule changes, moves into a CalendarViewHost shared by the single-date and range calendars
- Tests: DateRangeSelectionTest (commonTest) and AdaptiveDateRangePickerStateTest (desktopTest, incl. rendering inside a vertically scrolling column and a live rule change)
- Docs: range picker section; sample gains a range section