### PR TITLE
feat(io): add KmpFile.source() for streaming reads with kotlinx-io

### DIFF
--- a/calf-io/build.gradle.kts
+++ b/calf-io/build.gradle.kts
@@ -6,6 +6,15 @@ plugins {
 kotlin {
     sourceSets.commonMain.dependencies {
         api(projects.calfCore)
+        api(libs.kotlinx.io.core)
+    }
+
+    sourceSets.commonTest.dependencies {
+        implementation(libs.kotlin.test)
+    }
+
+    sourceSets.desktopTest.dependencies {
+        implementation(libs.kotlinx.coroutines.core)
     }
 
     sourceSets.androidMain.dependencies {

--- a/calf-io/src/androidMain/kotlin/com/mohamedrejeb/calf/io/KmpFileSource.android.kt
+++ b/calf-io/src/androidMain/kotlin/com/mohamedrejeb/calf/io/KmpFileSource.android.kt
@@ -1,0 +1,10 @@
+package com.mohamedrejeb.calf.io
+
+import com.mohamedrejeb.calf.core.PlatformContext
+import kotlinx.io.RawSource
+import kotlinx.io.asSource
+import java.io.FileNotFoundException
+
+actual suspend fun KmpFile.source(context: PlatformContext): RawSource =
+    context.contentResolver.openInputStream(uri)?.asSource()
+        ?: throw FileNotFoundException("Unable to open $uri")

--- a/calf-io/src/commonMain/kotlin/com.mohamedrejeb.calf/io/KmpFileSource.kt
+++ b/calf-io/src/commonMain/kotlin/com.mohamedrejeb.calf/io/KmpFileSource.kt
@@ -1,0 +1,40 @@
+package com.mohamedrejeb.calf.io
+
+import com.mohamedrejeb.calf.core.PlatformContext
+import kotlinx.io.RawSource
+
+/**
+ * Opens the content of the KmpFile as a kotlinx-io [RawSource] for streaming reads, so large
+ * files can be processed without loading them into memory.
+ *
+ * Wrap the result with `buffered()` to get a [kotlinx.io.Source], and always close it, for
+ * example with `use { }`.
+ *
+ * Platform behaviour:
+ * - **Android**: opened through `ContentResolver.openInputStream`, so content URIs from the
+ *   Storage Access Framework, Google Drive or Downloads stream directly even though [getPath]
+ *   returns a URI rather than a file system path.
+ * - **iOS** and **Desktop**: opened from the file system.
+ * - **JS** and **Wasm**: browsers offer no synchronous file reads, so the whole file is read
+ *   into memory first and served from a [kotlinx.io.Buffer].
+ *
+ * Opening and reading are blocking I/O on Android, iOS and Desktop. Call `source()` and
+ * consume the returned source from a background dispatcher such as `Dispatchers.IO` or
+ * `Dispatchers.Default`, never from the main thread.
+ *
+ * @param context The platform context used to open the file.
+ * @return A [RawSource] positioned at the start of the file.
+ * @throws kotlinx.io.files.FileNotFoundException if the file cannot be opened.
+ */
+expect suspend fun KmpFile.source(context: PlatformContext): RawSource
+
+/**
+ * Opens the content of the KmpFile as a kotlinx-io [RawSource] for streaming reads.
+ *
+ * On Android, requires that a Calf `rememberFilePickerLauncher` composable has been used first
+ * to initialize the internal context. Otherwise, use the overload that accepts a
+ * [PlatformContext].
+ *
+ * @see source
+ */
+suspend fun KmpFile.source(): RawSource = source(resolveContext())

--- a/calf-io/src/desktopMain/kotlin/com/mohamedrejeb/calf/io/KmpFileSource.desktop.kt
+++ b/calf-io/src/desktopMain/kotlin/com/mohamedrejeb/calf/io/KmpFileSource.desktop.kt
@@ -1,0 +1,9 @@
+package com.mohamedrejeb.calf.io
+
+import com.mohamedrejeb.calf.core.PlatformContext
+import kotlinx.io.RawSource
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+actual suspend fun KmpFile.source(context: PlatformContext): RawSource =
+    SystemFileSystem.source(Path(file.absolutePath))

--- a/calf-io/src/desktopTest/kotlin/com/mohamedrejeb/calf/io/KmpFileSourceTest.kt
+++ b/calf-io/src/desktopTest/kotlin/com/mohamedrejeb/calf/io/KmpFileSourceTest.kt
@@ -1,0 +1,104 @@
+package com.mohamedrejeb.calf.io
+
+import com.mohamedrejeb.calf.core.PlatformContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.Buffer
+import kotlinx.io.IOException
+import kotlinx.io.buffered
+import kotlinx.io.files.FileNotFoundException
+import kotlinx.io.readByteArray
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+private const val FILE_SIZE = 100_003
+private const val CHUNK_SIZE = 4_096L
+
+class KmpFileSourceTest {
+
+    private val content = ByteArray(FILE_SIZE) { index -> (index % 251).toByte() }
+
+    private val file: File = File.createTempFile("calf-source-test", ".bin").apply {
+        writeBytes(content)
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        file.delete()
+    }
+
+    @Test
+    fun `source streams the whole file content`() = runBlocking {
+        val bytes = KmpFile(file).source(PlatformContext.INSTANCE).buffered().use { source ->
+            source.readByteArray()
+        }
+
+        assertContentEquals(content, bytes)
+    }
+
+    @Test
+    fun `source can be consumed in chunks smaller than the file`() = runBlocking {
+        val chunk = Buffer()
+        var total = 0L
+        var largestRead = 0L
+
+        KmpFile(file).source(PlatformContext.INSTANCE).use { source ->
+            while (true) {
+                val read = source.readAtMostTo(chunk, CHUNK_SIZE)
+                if (read == -1L) break
+                largestRead = maxOf(largestRead, read)
+                total += read
+                chunk.clear()
+            }
+        }
+
+        assertEquals(FILE_SIZE.toLong(), total)
+        assertTrue(largestRead <= CHUNK_SIZE)
+    }
+
+    @Test
+    fun `context-free overload streams the file on desktop`() = runBlocking {
+        val bytes = KmpFile(file).source().buffered().use { it.readByteArray() }
+
+        assertContentEquals(content, bytes)
+    }
+
+    @Test
+    fun `source fails with FileNotFoundException for a missing file`() = runBlocking {
+        val missing = File(file.parentFile, "calf-source-missing-${file.name}")
+
+        assertFailsWith<FileNotFoundException> {
+            KmpFile(missing).source(PlatformContext.INSTANCE)
+        }
+        Unit
+    }
+
+    @Test
+    fun `source of an empty file reports end of stream immediately`() = runBlocking {
+        val empty = File.createTempFile("calf-source-empty", ".bin")
+        try {
+            val read = KmpFile(empty).source(PlatformContext.INSTANCE).use { source ->
+                source.readAtMostTo(Buffer(), CHUNK_SIZE)
+            }
+
+            assertEquals(-1L, read)
+        } finally {
+            empty.delete()
+        }
+    }
+
+    @Test
+    fun `use closes the underlying stream`() = runBlocking {
+        val source = KmpFile(file).source(PlatformContext.INSTANCE)
+        source.use { }
+
+        assertFailsWith<IOException> {
+            source.readAtMostTo(Buffer(), CHUNK_SIZE)
+        }
+        Unit
+    }
+}

--- a/calf-io/src/iosMain/kotlin/com.mohamedrejeb.calf/io/KmpFileSource.ios.kt
+++ b/calf-io/src/iosMain/kotlin/com.mohamedrejeb.calf/io/KmpFileSource.ios.kt
@@ -1,0 +1,12 @@
+package com.mohamedrejeb.calf.io
+
+import com.mohamedrejeb.calf.core.PlatformContext
+import kotlinx.io.RawSource
+import kotlinx.io.files.FileNotFoundException
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+actual suspend fun KmpFile.source(context: PlatformContext): RawSource {
+    val path = url.path ?: throw FileNotFoundException("No file system path for $url")
+    return SystemFileSystem.source(Path(path))
+}

--- a/calf-io/src/webMain/kotlin/com.mohamedrejeb.calf/io/KmpFileSource.web.kt
+++ b/calf-io/src/webMain/kotlin/com.mohamedrejeb.calf/io/KmpFileSource.web.kt
@@ -1,0 +1,8 @@
+package com.mohamedrejeb.calf.io
+
+import com.mohamedrejeb.calf.core.PlatformContext
+import kotlinx.io.Buffer
+import kotlinx.io.RawSource
+
+actual suspend fun KmpFile.source(context: PlatformContext): RawSource =
+    Buffer().apply { write(readFileAsBytes(file)) }

--- a/docs/filepicker.md
+++ b/docs/filepicker.md
@@ -239,7 +239,7 @@ LaunchedEffect(file) {
 
 > The `readByteArray` extension function is a suspending function, so you need to call it from a coroutine scope.
 
-> It's not recommended to use `readByteArray` extension function on large files, as it reads the entire file into memory.
+> It's not recommended to use `readByteArray` extension function on large files, as it reads the entire file into memory. See [Streaming with kotlinx-io](#streaming-with-kotlinx-io) to read it as a stream instead.
 > For large files, it's recommended to use the platform-specific APIs to read the file.
 > You can read more about accessing the platform-specific APIs below.
 
@@ -357,6 +357,43 @@ val file: java.io.File = kmpFile.file
 ##### Web
 ```kotlin
 val file: org.w3c.files.File = kmpFile.file
+```
+
+## Streaming with kotlinx-io
+
+Reading a large file with `readByteArray` loads it fully into memory. To stream it instead, for example to feed a zip reader or a parser, use the `source()` extension. It opens the file as a [kotlinx-io](https://github.com/Kotlin/kotlinx-io) `RawSource`; kotlinx-io is a dependency of `calf-io`, so nothing extra needs to be added:
+
+```kotlin
+import com.mohamedrejeb.calf.io.source
+
+suspend fun importFile(file: KmpFile) {
+    file.source().buffered().use { source ->
+        val header = source.readByteArray(4)
+        // keep reading from `source` in chunks
+    }
+}
+```
+
+`source()` is a suspending function. Like the other extensions it has an overload that takes a `PlatformContext` for Android code that runs outside a Calf composable. Always close the returned source.
+
+| Platform | How the file is opened |
+|---|---|
+| Android | `ContentResolver.openInputStream`, so content URIs from the Storage Access Framework, Google Drive or Downloads stream directly. `getPath()` returns the URI string on Android, not a file system path, so use `source()` rather than opening the path yourself. |
+| iOS, Desktop | From the file system through `SystemFileSystem`. |
+| JS, Wasm | Browsers offer no synchronous file reads, so the whole file is read into memory first and served from a `Buffer`. |
+
+### Using okio
+
+If your code is built on [okio](https://square.github.io/okio/), convert the source with the official [kotlinx-io-okio](https://github.com/Kotlin/kotlinx-io) bridge:
+
+```kotlin
+implementation("org.jetbrains.kotlinx:kotlinx-io-okio:<kotlinx-io version>")
+```
+
+```kotlin
+import kotlinx.io.okio.asOkioSource
+
+val okioSource: okio.Source = file.source().asOkioSource()
 ```
 
 ## Coil Extensions

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ compose = "1.11.1"
 material3 = "1.11.0-alpha07"
 material-icons-extended = "1.7.3"
 kotlinx-datetime = "0.7.1"
+kotlinx-io = "0.9.1"
 kotlinx-browser = "0.5.0"
 vanniktech-maven-publish = "0.36.0"
 documentfile = "1.1.0"
@@ -49,6 +50,7 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-javafx = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-javafx", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 vanniktech-maven-publish = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version.ref = "vanniktech-maven-publish" }
 
 compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "compose" }

--- a/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/FilePickerScreen.kt
+++ b/sample/common/src/commonMain/kotlin/com.mohamedrejeb.calf.sample/screens/FilePickerScreen.kt
@@ -21,12 +21,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.calf.io.KmpFile
 import com.mohamedrejeb.calf.io.getName
 import com.mohamedrejeb.calf.io.getPath
+import com.mohamedrejeb.calf.io.source
 import com.mohamedrejeb.calf.picker.FilePickerFileType
 import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
 import com.mohamedrejeb.calf.picker.FilePickerSettings
@@ -38,6 +41,13 @@ import com.mohamedrejeb.calf.sample.components.SampleScreenScaffold
 import com.mohamedrejeb.calf.sample.currentPlatform
 import com.mohamedrejeb.calf.ui.button.AdaptiveButton
 import com.mohamedrejeb.calf.ui.toggle.AdaptiveSwitch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.io.Buffer
+import kotlinx.io.RawSource
 
 private data class FileTypeOption(
     val label: String,
@@ -54,9 +64,15 @@ private val fileTypeOptions = listOf(
     FileTypeOption("Text", FilePickerFileType.Text),
 )
 
+private const val STREAM_CHUNK_SIZE = 64L * 1024
+private const val STREAMING_IN_PROGRESS = "Streaming with kotlinx-io…"
+private const val DIRECTORY_NOT_STREAMED = "Directory, not streamed"
+
 private data class PickedFileInfo(
+    val file: KmpFile,
     val name: String,
     val path: String,
+    val streamingSummary: String,
 )
 
 @Composable
@@ -69,6 +85,24 @@ fun FilePickerScreen(navigateBack: () -> Unit) {
 
     val selectedFileType = fileTypeOptions[selectedTypeIndex].type
 
+    val scope = rememberCoroutineScope()
+    var streamingJob: Job? by remember { mutableStateOf(null) }
+
+    val onFilesPicked: (List<KmpFile>) -> Unit = { files ->
+        pickedFiles = files.map { file -> file.toPickedFileInfo(STREAMING_IN_PROGRESS) }
+        streamingJob?.cancel()
+        streamingJob = scope.launch {
+            pickedFiles = pickedFiles.map { info ->
+                info.copy(streamingSummary = info.file.describeStreaming())
+            }
+        }
+    }
+
+    val onDirectoryPicked: (List<KmpFile>) -> Unit = { files ->
+        streamingJob?.cancel()
+        pickedFiles = files.map { file -> file.toPickedFileInfo(DIRECTORY_NOT_STREAMED) }
+    }
+
     val settings = rememberFilePickerSettings(
         title = dialogTitle,
         initialDirectory = initialDirectory,
@@ -79,42 +113,21 @@ fun FilePickerScreen(navigateBack: () -> Unit) {
         type = selectedFileType,
         selectionMode = FilePickerSelectionMode.Single,
         settings = settings,
-        onResult = { files ->
-            pickedFiles = files.map { file ->
-                PickedFileInfo(
-                    name = file.getName().orEmpty(),
-                    path = file.getPath() ?: "Unknown path",
-                )
-            }
-        },
+        onResult = onFilesPicked,
     )
 
     val multiplePickerLauncher = rememberFilePickerLauncher(
         type = selectedFileType,
         selectionMode = FilePickerSelectionMode.Multiple,
         settings = settings,
-        onResult = { files ->
-            pickedFiles = files.map { file ->
-                PickedFileInfo(
-                    name = file.getName().orEmpty(),
-                    path = file.getPath() ?: "Unknown path",
-                )
-            }
-        },
+        onResult = onFilesPicked,
     )
 
     val directoryPickerLauncher = rememberFilePickerLauncher(
         type = FilePickerFileType.Folder,
         selectionMode = FilePickerSelectionMode.Single,
         settings = FilePickerSettings(title = "Pick a directory"),
-        onResult = { files ->
-            pickedFiles = files.map { file ->
-                PickedFileInfo(
-                    name = file.getName().orEmpty(),
-                    path = file.getPath() ?: "Unknown path",
-                )
-            }
-        },
+        onResult = onDirectoryPicked,
     )
 
     val initialDirectoryPickerLauncher = rememberFilePickerLauncher(
@@ -286,8 +299,47 @@ fun FilePickerScreen(navigateBack: () -> Unit) {
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    Text(
+                        text = fileInfo.streamingSummary,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
                 }
             }
         }
+    }
+}
+
+/**
+ * Reads the whole file through the kotlinx-io [source] extension in fixed-size chunks, so the
+ * file never has to fit in memory, and describes the outcome for the results list.
+ */
+private suspend fun KmpFile.describeStreaming(): String = withContext(Dispatchers.Default) {
+    try {
+        val bytes = source().use { source -> source.countBytes() }
+        "$bytes bytes read in ${STREAM_CHUNK_SIZE / 1024} KB chunks with kotlinx-io"
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        "Not streamable: ${e.message}"
+    }
+}
+
+private fun KmpFile.toPickedFileInfo(streamingSummary: String): PickedFileInfo =
+    PickedFileInfo(
+        file = this,
+        name = getName().orEmpty(),
+        path = getPath() ?: "Unknown path",
+        streamingSummary = streamingSummary,
+    )
+
+private fun RawSource.countBytes(): Long {
+    val chunk = Buffer()
+    var total = 0L
+    while (true) {
+        val read = readAtMostTo(chunk, STREAM_CHUNK_SIZE)
+        if (read == -1L) return total
+        total += read
+        chunk.clear()
     }
 }


### PR DESCRIPTION
Closes #537.

Large picked files could only be read with readByteArray(), which loads them fully into memory; on Android getPath() returns a content URI, so there was no way to stream them at all.

- calf-io now depends on kotlinx-io (api) and exposes `suspend fun KmpFile.source(context): kotlinx.io.RawSource` plus a context-free overload next to the other KmpFile extensions
- Android opens the content URI through ContentResolver, iOS and desktop go through SystemFileSystem, JS/Wasm buffer the file in memory because browsers have no synchronous reads
- kotlinx-io 0.9.1 added to the version catalog
- Docs: "Streaming with kotlinx-io" section in docs/filepicker.md, including the okio bridge via kotlinx-io-okio
- Sample: file picker screen streams each picked file in 64 KB chunks
- Tests: KmpFileSourceTest (calf-io desktopTest, 6 tests)